### PR TITLE
rename again: Download => Downloads

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "Download"
+name = "Downloads"
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 authors = ["Stefan Karpinski <stefan@karpinski.org> and contributors"]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Download
+# Downloads

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -1,4 +1,4 @@
-module Download
+module Downloads
 
 include("Curl/Curl.jl")
 using .Curl

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 include("setup.jl")
 
-@testset "Download.jl" begin
+@testset "Downloads.jl" begin
     @testset "get request" begin
         url = "$server/get"
         data = download_json(url)
@@ -48,15 +48,15 @@ include("setup.jl")
     end
 
     @testset "errors" begin
-        err = @exception Download.download("xyz://invalid")
+        err = @exception Downloads.download("xyz://invalid")
         @test err isa ErrorException
         @test startswith(err.msg, "Protocol \"xyz\" not supported")
 
-        err = @exception Download.download("https://invalid")
+        err = @exception Downloads.download("https://invalid")
         @test err isa ErrorException
         @test startswith(err.msg, "Could not resolve host")
 
-        err = @exception Download.download("$server/status/404")
+        err = @exception Downloads.download("$server/status/404")
         @test err isa ErrorException
         @test contains(err.msg, r"^HTTP/\d+(?:\.\d+)?\s+404\b")
     end
@@ -122,10 +122,10 @@ include("setup.jl")
         end
 
         @testset "progress" begin
-            progress = Download.Curl.Progress[]
+            progress = Downloads.Curl.Progress[]
             # https://httpbingo.org/drop doesn't work
             req = Request(devnull, "https://httpbin.org/drip", String[])
-            Download.request(req, multi, p -> push!(progress, p))
+            Downloads.request(req, multi, p -> push!(progress, p))
             unique!(progress)
             @test 11 ≤ length(progress) ≤ 12
             shift = length(progress) - 10

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -1,6 +1,6 @@
 using Test
-using Download
-using Download.Curl
+using Downloads
+using Downloads.Curl
 
 include("json.jl")
 
@@ -10,7 +10,7 @@ end
 
 function download_body(url::AbstractString, headers = Union{}[])
     sprint() do io
-        Download.download(url, io, headers = headers)
+        Downloads.download(url, io, headers = headers)
     end
 end
 
@@ -22,7 +22,7 @@ function request_body(multi::Multi, url::AbstractString, headers = Union{}[])
     resp = nothing
     body = sprint() do io
         req = Request(io, url, headers)
-        resp = Download.request(req, multi)
+        resp = Downloads.request(req, multi)
     end
     return resp, body
 end


### PR DESCRIPTION
`using Downloads` just reads better and there's the plural package naming convention as well.