### PR TITLE
Julia 1.6 / Win64 fix: use 1ms timeout hack on Win64

### DIFF
--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -80,13 +80,13 @@ function timer_callback(
     if timeout_ms == 0
         @check curl_multi_socket_action(multi.handle, CURL_SOCKET_TIMEOUT, 0)
     end
-    if timeout_ms >= 0
+    if timeout_ms > 0
         timeout_cb = @cfunction(timeout_callback, Cvoid, (Ptr{Cvoid},))
-        uv_timer_start(multi.timer, timeout_cb, max(1, timeout_ms), 0)
-        check_multi_info(multi)
+        uv_timer_start(multi.timer, timeout_cb, timeout_ms, 0)
     else
         uv_timer_stop(multi.timer)
     end
+    check_multi_info(multi)
     return 0
 end
 

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -80,9 +80,9 @@ function timer_callback(
     if timeout_ms == 0
         @check curl_multi_socket_action(multi.handle, CURL_SOCKET_TIMEOUT, 0)
     end
-    if timeout_ms > 0
+    if timeout_ms >= 0
         timeout_cb = @cfunction(timeout_callback, Cvoid, (Ptr{Cvoid},))
-        uv_timer_start(multi.timer, timeout_cb, timeout_ms, 0)
+        uv_timer_start(multi.timer, timeout_cb, max(1, timeout_ms), 0)
     else
         uv_timer_stop(multi.timer)
     end

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -79,10 +79,11 @@ function timer_callback(
     @assert handle_p == multi.handle
     if timeout_ms == 0
         @check curl_multi_socket_action(multi.handle, CURL_SOCKET_TIMEOUT, 0)
-        check_multi_info(multi)
-    elseif timeout_ms > 0
+    end
+    if timeout_ms >= 0
         timeout_cb = @cfunction(timeout_callback, Cvoid, (Ptr{Cvoid},))
-        uv_timer_start(multi.timer, timeout_cb, timeout_ms, 0)
+        uv_timer_start(multi.timer, timeout_cb, max(1, timeout_ms), 0)
+        check_multi_info(multi)
     else
         uv_timer_stop(multi.timer)
     end

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -77,16 +77,12 @@ function timer_callback(
 )::Cint
     multi = unsafe_pointer_to_objref(multi_p)::Multi
     @assert handle_p == multi.handle
-    if timeout_ms >= 0
-        # FIXME: ideally we wouldn't special case Windows here
-        if !Sys.iswindows() && timeout_ms == 0
-            @check curl_multi_socket_action(multi.handle, CURL_SOCKET_TIMEOUT, 0)
-            check_multi_info(multi)
-        end
-        if Sys.iswindows() || timeout_ms > 0
-            timeout_cb = @cfunction(timeout_callback, Cvoid, (Ptr{Cvoid},))
-            uv_timer_start(multi.timer, timeout_cb, max(1, timeout_ms), 0)
-        end
+    if timeout_ms == 0
+        @check curl_multi_socket_action(multi.handle, CURL_SOCKET_TIMEOUT, 0)
+        check_multi_info(multi)
+    elseif timeout_ms > 0
+        timeout_cb = @cfunction(timeout_callback, Cvoid, (Ptr{Cvoid},))
+        uv_timer_start(multi.timer, timeout_cb, timeout_ms, 0)
     else
         uv_timer_stop(multi.timer)
     end


### PR DESCRIPTION
This shouldn't be necessary and doesn't seem to be on older Julia
versions, but for some reason on Julia master the first download
hangs forever on Win64 unless we do this the old hacky way.