### PR TITLE
fix broken download(url, path; headers) method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - windows
 julia:
   - 1.3
-  - nightly
+  - 1.5
 notifications:
   email: false
 codecov: true

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,14 @@
 name = "Downloads"
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 authors = ["Stefan Karpinski <stefan@karpinski.org> and contributors"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
+ArgTools = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 LibCURL = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 
 [compat]
+ArgTools = "1.1"
 LibCURL = "0.6"
 julia = "1.3"
 

--- a/README.md
+++ b/README.md
@@ -12,19 +12,16 @@ Julia 1.3 through 1.5 as well.
 ## API
 
 ```jl
-download(url, [ path = tempfile() ]; [ headers ]) -> path
-download(url, io; [ headers ]) -> io
+download(url, [ output = tempfile() ]; [ headers ]) -> output
 ```
+* `url     :: AbstractString`
+* `output  :: Union{AbstractString, AbstractCmd, IO}`
+* `headers :: Union{AbstractVector, AbstractDict}`
 
-- `url     :: AbstractString`
-- `path    :: AbstractString`
-- `io      :: IO`
-- `headers :: Union{AbstractVector, AbstractDict}`
-
-Download a file from the given url, saving it to the location `path`, or if not
-specified, a temporary path. Returns the path of the downloaded file. If the
-second argument is an IO handle instead of a path, the body of the downloaded
-URL is written to the handle instead and the handle is returned.
+Download a file from the given url, saving it to `output` or if not specified,
+a temporary path. The `output` can also be an `IO` handle, in which case the
+body of the response is streamed to that handle and the handle is returned. If
+`output` is a command, the command is run and output is sent to it on stdin.
 
 If the `headers` keyword argument is provided, it must be a vector or dictionary
 whose elements are all pairs of strings. These pairs are passed as headers when

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,39 @@
 include("setup.jl")
 
 @testset "Downloads.jl" begin
+    @testset "API coverage" begin
+        value = "Julia is great!"
+        base64 = "SnVsaWEgaXMgZ3JlYXQh"
+        url = "$server/base64/$base64"
+        headers = ["Foo" => "Bar"]
+        # test with one argument
+        path = Downloads.download(url)
+        @test isfile(path)
+        @test value == read(path, String)
+        rm(path)
+        # with headers
+        path = Downloads.download(url, headers=headers)
+        @test isfile(path)
+        @test value == read(path, String)
+        rm(path)
+        # test with two arguments
+        arg_writers() do path, output
+            @arg_test output begin
+                @test output == Downloads.download(url, output)
+            end
+            @test isfile(path)
+            @test value == read(path, String)
+            rm(path)
+            # with headers
+            @arg_test output begin
+                @test output == Downloads.download(url, output, headers=headers)
+            end
+            @test isfile(path)
+            @test value == read(path, String)
+            rm(path)
+        end
+    end
+
     @testset "get request" begin
         url = "$server/get"
         data = download_json(url)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -1,4 +1,5 @@
 using Test
+using ArgTools
 using Downloads
 using Downloads.Curl
 


### PR DESCRIPTION
This method was broken because of a trivial typo: `,` versus `;` in
the method signature, which escaped notice because the tests were not
sufficiently thorough. I could just fix the typo and add some more
tests, but since (a) this is exactly the kind of thing ArgTools is for
and (b) the Tar stdlib already depends on ArgTools, we might as well
just use it and use its test utilities for more thorough testing.