### PR TITLE
Multi: add grace period before calling done! (default: 30s)

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -13,7 +13,12 @@ export download
 struct Downloader
     multi::Multi
 end
-Downloader() = Downloader(Multi())
+Downloader(; grace::Real=30) = Downloader(Multi(grace_ms(grace)))
+
+function grace_ms(grace::Real)
+    grace < 0 && throw(ArgumentError("grace period cannot be negative: $grace"))
+    grace <= typemax(UInt64) ÷ 1000 ? round(UInt64, 1000*grace) : typemax(UInt64)
+end
 
 const DOWNLOAD_LOCK = ReentrantLock()
 const DOWNLOADER = Ref{Union{Downloader, Nothing}}(nothing)


### PR DESCRIPTION
This uses the Multi object's already-allocated timer to set a timer when the number of in-progress downloads reaches zero, to clean up the curl multi-handle and associated resources when the timer goes off. If another download is started before then, then the timer is started again once the number of downloads reaches zero again. If a Multi object is garbage collected before its cleaup timer fires, it will be finalized earlier, so the cleanup occurs at the earlier of the two. If the grace period is zero, then `done!` is called immediately when the number of concurrent downloads reaches zero. If the grace period is larger than `typemax(UInt64) ÷ 1000` then no timer is set and the cleanup only occurs when the Multi object is garbage collected.