### PR TITLE
errors: 2xx = success; more info in error messages

### DIFF
--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -10,6 +10,7 @@ export
         get_effective_url,
         get_response_code,
         get_response_headers,
+        get_error_message,
     Multi,
         add_handle,
         remove_handle

--- a/src/Curl/utils.jl
+++ b/src/Curl/utils.jl
@@ -1,5 +1,9 @@
 # basic C stuff
 
+if !@isdefined(contains)
+    contains(haystack, needle) = occursin(needle, haystack)
+end
+
 puts(s::Union{String,SubString{String}}) = ccall(:puts, Cint, (Ptr{Cchar},), s)
 
 jl_malloc(n::Integer) = ccall(:jl_malloc, Ptr{Cvoid}, (Csize_t,), n)

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -83,15 +83,8 @@ function download(
                 remove_handle(downloader.multi, easy)
             end
             status = get_response_code(easy)
-            status == 200 && return
-            message = if easy.code == Curl.CURLE_OK
-                get_response_headers(easy)[1]
-            elseif easy.errbuf[1] == 0
-                unsafe_string(Curl.curl_easy_strerror(easy.code))
-            else
-                GC.@preserve easy unsafe_string(pointer(easy.errbuf))
-            end
-            message = chomp(message)
+            200 ≤ status < 300 && return
+            message = get_error_message(easy)
             error("$message while downloading $url")
         end
     end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -2,12 +2,9 @@ using Test
 using ArgTools
 using Downloads
 using Downloads.Curl
+using Downloads.Curl: contains
 
 include("json.jl")
-
-if VERSION < v"1.5"
-    contains(haystack, needle) = occursin(needle, haystack)
-end
 
 function download_body(url::AbstractString; headers=Union{}[], downloader=nothing)
     sprint() do io


### PR DESCRIPTION
- Any 2xx status is a success, not just 200
- Most of the time the response mentions the status code; if it doesn't, we should still include it in the error message
- If curl error message is empty, at least include the error code
- Generally we print the response status message before the curl error message since it is often more specific/informative
- However, if the response status message is empty, we print the curl error message first and include the status code in parens