### PR TITLE
ftp: add temporary tests to make sure that ftp downloads work

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,6 +201,14 @@ include("setup.jl")
             end
         end
     end
+
+    @testset "ftp download" begin
+        file = Downloads.download("ftp://xmlsoft.org/libxslt/libxslt-1.1.33.tar.gz")
+        @test isfile(file)
+        @test filesize(file) == 3444093
+        head = String(read!(open(file), Vector{UInt8}(undef, 16)))
+        @test head == "\x1f\x8b\b\0\xa5T.\\\x02\x03\xec]{s۶"
+    end
 end
 
 Downloads.DOWNLOADER[] = nothing


### PR DESCRIPTION
This currently fails as discussed in https://github.com/JuliaLang/Downloads.jl/pull/43. The issue seems to be that switching to FTP passive mode tell the client a `:<port>` to connect to, which macOS interprets as connecting to a different port on the same host but Linux interprets, incorrectly, as connecting to that port on a host with the name `""` which is obviously not going to work.