### PR TITLE
tests: improve reliability locally and during CI

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,11 +93,11 @@ include("setup.jl")
         @test_throws ArgumentError Downloads.download("ba\0d")
         @test_throws ArgumentError Downloads.download("good", "ba\0d")
 
-        err = @exception Downloads.download("xyz://invalid")
+        err = @exception Downloads.download("xyz://domain.invalid")
         @test err isa ErrorException
         @test startswith(err.msg, "Protocol \"xyz\" not supported")
 
-        err = @exception Downloads.download("https://invalid")
+        err = @exception Downloads.download("https://domain.invalid")
         @test err isa ErrorException
         @test startswith(err.msg, "Could not resolve host")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,20 +184,22 @@ include("setup.jl")
                 progress = Downloads.Curl.Progress[]
                 req = Request(devnull, url, String[])
                 Downloads.request(req, multi; progress = p -> push!(progress, p))
-                unique!(progress)
-                @test 11 ≤ length(progress) ≤ 12
-                shift = length(progress) - 10
-                @test all(p.dl_total == (i==1 ? 0 : 10) for (i, p) in enumerate(progress))
-                @test all(p.dl_now   == max(0, i-shift) for (i, p) in enumerate(progress))
+                @test progress[1].dl_total == 0
+                @test progress[1].dl_now == 0
+                @test progress[end].dl_total == 10
+                @test progress[end].dl_now == 10
+                @test issorted(p.dl_total for p in progress)
+                @test issorted(p.dl_now for p in progress)
             end
             @testset "download" begin
                 progress = Downloads.Curl.Progress[]
                 Downloads.download(url; progress = p -> push!(progress, p))
-                unique!(progress)
-                @test 11 ≤ length(progress) ≤ 12
-                shift = length(progress) - 10
-                @test all(p.dl_total == (i==1 ? 0 : 10) for (i, p) in enumerate(progress))
-                @test all(p.dl_now   == max(0, i-shift) for (i, p) in enumerate(progress))
+                @test progress[1].dl_total == 0
+                @test progress[1].dl_now == 0
+                @test progress[end].dl_total == 10
+                @test progress[end].dl_now == 10
+                @test issorted(p.dl_total for p in progress)
+                @test issorted(p.dl_now for p in progress)
             end
         end
     end


### PR DESCRIPTION
* significanly relax progress tests (fix #31, fix #47)
* use `domain.invalid` as invalid domain name