### PR TITLE
download: backwards compatibility for progress callback

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -90,6 +90,12 @@ function download(
     verbose    :: Bool = false,
     downloader :: Union{Downloader, Nothing} = nothing,
 ) :: ArgWrite
+    if !hasmethod(progress, Tuple{Int,Int}) &&
+        hasmethod(progress, Tuple{Any})
+        original_progress = progress
+        progress = (total, now) ->
+            original_progress((dl_total = total, dl_now = now))
+    end
     arg_write(output) do output
         response = request(
             url,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -196,6 +196,16 @@ include("setup.jl")
                 @test issorted(p[1] for p in progress)
                 @test issorted(p[2] for p in progress)
             end
+            @testset "download (compat)" begin
+                progress = NTuple{2,Int}[]
+                download(url; progress = p -> push!(progress, (p.dl_total, p.dl_now)))
+                @test progress[1][1] == 0
+                @test progress[1][2] == 0
+                @test progress[end][1] == 10
+                @test progress[end][2] == 10
+                @test issorted(p[1] for p in progress)
+                @test issorted(p[2] for p in progress)
+            end
         end
     end
 end


### PR DESCRIPTION
This allows code (like Pkg) using the old progress API to keep working. We'll delete this after Pkg adjusts, but for now it's easier to update things if we support both APIs.