### PR TITLE
request with no `output` defaults to `HEAD` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ request(url;
 Make a request to the given url, returning a `Response` object capturing the
 status, headers and other information about the response. The body of the
 reponse is written to `output` if specified and discarded otherwise. The
-folowing options differ from the `download` function:
+following options differ from the `download` function:
 
-- `input` allows providing a request body; if provided default to PUT request
+- `input` allows providing a request body; if provided default to `PUT` request
 - `progress` is a callback taking four integers for upload and download progress
 - `throw` controls whether to throw or return a `RequestError` on request error
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ the download functionality will print debugging information to `stderr`.
 
 ```jl
 request(url;
-    [ input = devnull, ]
-    [ output = devnull, ]
-    [ method = "GET", ]
+    [ input = <none>, ]
+    [ output = <none>, ]
+    [ method = input ? "PUT" : output ? "GET" : "HEAD", ]
     [ headers = <none>, ]
     [ progress = <none>, ]
     [ verbose = false, ]
@@ -91,8 +91,12 @@ request(url;
 
 Make a request to the given url, returning a `Response` object capturing the
 status, headers and other information about the response. The body of the
-reponse is written to `output` if specified and discarded otherwise. The
-following options differ from the `download` function:
+reponse is written to `output` if specified and discarded otherwise. For HTTP/S
+requests, if an `input` stream is given, a `PUT` request is made; otherwise if
+an `output` stream is givven, a `GET` request is made; if neither is given a
+`HEAD` request is made. For other protocols, appropriate default methods are
+used based on what combination of input and output are requested. The following
+options differ from the `download` function:
 
 - `input` allows providing a request body; if provided default to `PUT` request
 - `progress` is a callback taking four integers for upload and download progress

--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -6,6 +6,7 @@ export
         set_url,
         set_method,
         set_verbose,
+        set_body,
         set_upload_size,
         set_seeker,
         add_headers,

--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -74,6 +74,10 @@ function set_verbose(easy::Easy, verbose::Bool)
     @check curl_easy_setopt(easy.handle, CURLOPT_VERBOSE, verbose)
 end
 
+function set_body(easy::Easy, body::Bool)
+    @check curl_easy_setopt(easy.handle, CURLOPT_NOBODY, !body)
+end
+
 function set_upload_size(easy::Easy, size::Integer)
     @check curl_easy_setopt(easy.handle, CURLOPT_INFILESIZE_LARGE, size)
 end

--- a/src/Curl/utils.jl
+++ b/src/Curl/utils.jl
@@ -2,6 +2,7 @@
 
 if !@isdefined(contains)
     contains(haystack, needle) = occursin(needle, haystack)
+    export contains
 end
 
 puts(s::Union{String,SubString{String}}) = ccall(:puts, Cint, (Ptr{Cchar},), s)

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -220,9 +220,9 @@ end
 Make a request to the given url, returning a `Response` object capturing the
 status, headers and other information about the response. The body of the
 reponse is written to `output` if specified and discarded otherwise. The
-folowing options differ from the `download` function:
+following options differ from the `download` function:
 
-- `input` allows providing a request body; if provided default to PUT request
+- `input` allows providing a request body; if provided default to `PUT` request
 - `progress` is a callback taking four integers for upload and download progress
 - `throw` controls whether to throw or return a `RequestError` on request error
 

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -197,9 +197,9 @@ end
 
 """
     request(url;
-        [ input = devnull, ]
-        [ output = devnull, ]
-        [ method = "GET", ]
+        [ input = <none>, ]
+        [ output = <none>, ]
+        [ method = input ? "PUT" : output ? "GET" : "HEAD", ]
         [ headers = <none>, ]
         [ progress = <none>, ]
         [ verbose = false, ]
@@ -219,8 +219,12 @@ end
 
 Make a request to the given url, returning a `Response` object capturing the
 status, headers and other information about the response. The body of the
-reponse is written to `output` if specified and discarded otherwise. The
-following options differ from the `download` function:
+reponse is written to `output` if specified and discarded otherwise. For HTTP/S
+requests, if an `input` stream is given, a `PUT` request is made; otherwise if
+an `output` stream is givven, a `GET` request is made; if neither is given a
+`HEAD` request is made. For other protocols, appropriate default methods are
+used based on what combination of input and output are requested. The following
+options differ from the `download` function:
 
 - `input` allows providing a request body; if provided default to `PUT` request
 - `progress` is a callback taking four integers for upload and download progress
@@ -233,8 +237,8 @@ with getting a response at all, then a `RequestError` is thrown or returned.
 """
 function request(
     url        :: AbstractString;
-    input      :: ArgRead = devnull,
-    output     :: ArgWrite = devnull,
+    input      :: Union{ArgRead, Nothing} = nothing,
+    output     :: Union{ArgWrite, Nothing} = nothing,
     method     :: Union{AbstractString, Nothing} = nothing,
     headers    :: Union{AbstractVector, AbstractDict} = Pair{String,String}[],
     progress   :: Union{Function, Nothing} = nothing,
@@ -252,6 +256,10 @@ function request(
         end
     end
     local response
+    have_input = input !== nothing
+    have_output = output !== nothing
+    input = something(input, devnull)
+    output = something(output, devnull)
     input_size = arg_read_size(input)
     progress = p_func(progress, input, output)
     arg_read(input) do input
@@ -261,7 +269,7 @@ function request(
                 set_url(easy, url)
                 set_verbose(easy, verbose)
                 add_headers(easy, headers)
-                if input !== devnull
+                if have_input
                     enable_upload(easy)
                     if input_size !== nothing
                         set_upload_size(easy, input_size)
@@ -271,6 +279,8 @@ function request(
                             seek(input, Int(offset))
                         end
                     end
+                else
+                    set_body(easy, have_output)
                 end
                 method !== nothing && set_method(easy, method)
                 progress !== nothing && enable_progress(easy)
@@ -287,7 +297,7 @@ function request(
                                 progress(prog...)
                             end
                         end
-                        if input !== devnull
+                        if have_input
                             @async upload_data(easy, input)
                         end
                     end
@@ -326,6 +336,7 @@ p_func(progress::Nothing, input::ArgRead, output::ArgWrite) = nothing
 
 arg_read_size(path::AbstractString) = filesize(path)
 arg_read_size(io::IOBuffer) = io.size - io.ptr + 1
+arg_read_size(::Base.DevNull) = 0
 arg_read_size(::Any) = nothing
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -242,12 +242,17 @@ include("setup.jl")
         @testset "progress" begin
             url = "https://httpbingo.org/drip"
             progress = []
+            dl_funcs = [
+                download,
+                (url; progress) ->
+                    request(url, output=devnull, progress=progress)
+            ]
             p_funcs = [
                 (prog...) -> push!(progress, prog),
                 (total, now) -> push!(progress, (total, now)),
                 (total, now, _, _) -> push!(progress, (total, now)),
             ]
-            for f in (download, request), p in p_funcs
+            for f in dl_funcs, p in p_funcs
                 @testset "request" begin
                     empty!(progress)
                     f(url; progress = p)


### PR DESCRIPTION
We were already doing a `PUT` request if there is `input` to the request,
this extends that to do `GET` if there is `output` but
`HEAD` if there is no `input` or `output`. The implementation is a bit
sutbler than that: we use `libcurl`'s `CURLOPT_NOBODY` and
`CURLOPT_UPLOAD` options, which incidentally switches the default method
that it uses for HTTP/S requests and has corresponding appropriate effects
on uploads/downloads by other protocols.

This also changes the default for `input` and `output` to `nothing` instead
of using `devnull` as a sentinel, which had the unfortunate side-effect
that if explicitly pass `devnull` as an input or output argument, intending
to make the same request but provide an empty input or ignore any output,
it would change the behavior of the request. This was already present if
you tried to do a `PUT` with an empty request body: using `devnull` turned
it into a `GET` but using `"/dev/null"` or some other empty file didn't.
With `nothing` as a sentinel value, you can safely pass `devnull` as an
input or and output and have it work the same as any other value but empty.