### PR TITLE
download, request: add timeout keyword argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The public API of `Downloads` consists of two functions and three types:
 download(url, [ output = tempfile() ];
     [ method = "GET", ]
     [ headers = <none>, ]
+    [ timeout = <none>, ]
     [ progress = <none>, ]
     [ verbose = false, ]
     [ downloader = <default>, ]
@@ -37,6 +38,7 @@ download(url, [ output = tempfile() ];
 - `output     :: Union{AbstractString, AbstractCmd, IO}`
 - `method     :: AbstractString`
 - `headers    :: Union{AbstractVector, AbstractDict}`
+- `timeout    :: Real`
 - `progress   :: (total::Integer, now::Integer) --> Any`
 - `verbose    :: Bool`
 - `downloader :: Downloader`
@@ -55,6 +57,10 @@ See `Downloader` for more info about configuration and usage.
 If the `headers` keyword argument is provided, it must be a vector or dictionary
 whose elements are all pairs of strings. These pairs are passed as headers when
 downloading URLs with protocols that supports them, such as HTTP/S.
+
+The `timeout` keyword argument specifies a timeout for the download in seconds,
+with a resolution of milliseconds. By default no timeout is set, but this can
+also be explicitly requested by passing a timeout value of `Inf`.
 
 If the `progress` keyword argument is provided, it must be a callback funtion
 which will be called whenever there are updates about the size and status of the
@@ -76,6 +82,7 @@ request(url;
     [ output = <none>, ]
     [ method = input ? "PUT" : output ? "GET" : "HEAD", ]
     [ headers = <none>, ]
+    [ timeout = <none>, ]
     [ progress = <none>, ]
     [ verbose = false, ]
     [ throw = true, ]
@@ -87,6 +94,7 @@ request(url;
 - `output     :: Union{AbstractString, AbstractCmd, IO}`
 - `method     :: AbstractString`
 - `headers    :: Union{AbstractVector, AbstractDict}`
+- `timeout    :: Real`
 - `progress   :: (dl_total, dl_now, ul_total, ul_now) --> Any`
 - `verbose    :: Bool`
 - `throw      :: Bool`

--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -10,6 +10,7 @@ export
         set_upload_size,
         set_seeker,
         set_ca_roots_path,
+        set_timeout,
         add_headers,
         enable_upload,
         enable_progress,

--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -96,6 +96,18 @@ function set_seeker(seeker::Function, easy::Easy)
     easy.seeker = seeker
 end
 
+function set_timeout(easy::Easy, timeout::Real)
+    timeout > 0 ||
+        throw(ArgumentError("timeout must be positive, got $timeout"))
+    if timeout ≤ typemax(Clong) ÷ 1000
+        timeout_ms = round(Clong, timeout * 1000)
+        @check curl_easy_setopt(easy.handle, CURLOPT_TIMEOUT_MS, timeout_ms)
+    else
+        timeout = timeout ≤ typemax(Clong) ? round(Clong, timeout) : Clong(0)
+        @check curl_easy_setopt(easy.handle, CURLOPT_TIMEOUT, timeout)
+    end
+end
+
 function add_header(easy::Easy, hdr::Union{String, SubString{String}})
     # TODO: ideally, Clang would generate Cstring signatures
     Base.unsafe_convert(Cstring, hdr) # error checking

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -146,6 +146,7 @@ end
     download(url, [ output = tempfile() ];
         [ method = "GET", ]
         [ headers = <none>, ]
+        [ timeout = <none>, ]
         [ progress = <none>, ]
         [ verbose = false, ]
         [ downloader = <default>, ]
@@ -155,6 +156,7 @@ end
         output     :: Union{AbstractString, AbstractCmd, IO}
         method     :: AbstractString
         headers    :: Union{AbstractVector, AbstractDict}
+        timeout    :: Real
         progress   :: (total::Integer, now::Integer) --> Any
         verbose    :: Bool
         downloader :: Downloader
@@ -174,6 +176,10 @@ If the `headers` keyword argument is provided, it must be a vector or dictionary
 whose elements are all pairs of strings. These pairs are passed as headers when
 downloading URLs with protocols that supports them, such as HTTP/S.
 
+The `timeout` keyword argument specifies a timeout for the download in seconds,
+with a resolution of milliseconds. By default no timeout is set, but this can
+also be explicitly requested by passing a timeout value of `Inf`.
+
 If the `progress` keyword argument is provided, it must be a callback funtion
 which will be called whenever there are updates about the size and status of the
 ongoing download. The callback must take two integer arguments: `total` and
@@ -191,6 +197,7 @@ function download(
     output     :: Union{ArgWrite, Nothing} = nothing;
     method     :: Union{AbstractString, Nothing} = nothing,
     headers    :: Union{AbstractVector, AbstractDict} = Pair{String,String}[],
+    timeout    :: Real = Inf,
     progress   :: Union{Function, Nothing} = nothing,
     verbose    :: Bool = false,
     downloader :: Union{Downloader, Nothing} = nothing,
@@ -201,6 +208,7 @@ function download(
             output = output,
             method = method,
             headers = headers,
+            timeout = timeout,
             progress = progress,
             verbose = verbose,
             downloader = downloader,
@@ -218,6 +226,7 @@ end
         [ output = <none>, ]
         [ method = input ? "PUT" : output ? "GET" : "HEAD", ]
         [ headers = <none>, ]
+        [ timeout = <none>, ]
         [ progress = <none>, ]
         [ verbose = false, ]
         [ throw = true, ]
@@ -229,6 +238,7 @@ end
         output     :: Union{AbstractString, AbstractCmd, IO}
         method     :: AbstractString
         headers    :: Union{AbstractVector, AbstractDict}
+        timeout    :: Real
         progress   :: (dl_total, dl_now, ul_total, ul_now) --> Any
         verbose    :: Bool
         throw      :: Bool
@@ -258,6 +268,7 @@ function request(
     output     :: Union{ArgWrite, Nothing} = nothing,
     method     :: Union{AbstractString, Nothing} = nothing,
     headers    :: Union{AbstractVector, AbstractDict} = Pair{String,String}[],
+    timeout    :: Real = Inf,
     progress   :: Union{Function, Nothing} = nothing,
     verbose    :: Bool = false,
     throw      :: Bool = true,
@@ -284,6 +295,7 @@ function request(
             with_handle(Easy()) do easy
                 # setup the request
                 set_url(easy, url)
+                set_timeout(easy, timeout)
                 set_verbose(easy, verbose)
                 add_headers(easy, headers)
                 if have_input

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,6 +239,32 @@ include("setup.jl")
             @test json["url"] == url
         end
 
+        @testset "timeouts" begin
+            url = "$server/delay/2"
+            @testset "download" begin
+                @test_throws ArgumentError download(url, devnull, timeout = -1)
+                @test_throws ArgumentError download(url, devnull, timeout = 0)
+                @test_throws RequestError download(url, devnull, timeout = 1)
+                @test_throws RequestError download(url, devnull, timeout = 0.5)
+                @test download(url, devnull, timeout = 100) == devnull
+                @test download(url, devnull, timeout = Inf) == devnull
+            end
+            @testset "request(throw = true)" begin
+                @test_throws ArgumentError request(url, timeout = -1)
+                @test_throws ArgumentError request(url, timeout = 0)
+                @test_throws RequestError request(url, timeout = 1)
+                @test_throws RequestError request(url, timeout = 0.5)
+                @test request(url, timeout = 100) isa Response
+                @test request(url, timeout = Inf) isa Response
+            end
+            @testset "request(throw = false)" begin
+                @test request(url, throw = false, timeout = 1) isa RequestError
+                @test request(url, throw = false, timeout = 0.5) isa RequestError
+                @test request(url, throw = false, timeout = 100) isa Response
+                @test request(url, throw = false, timeout = Inf) isa Response
+            end
+        end
+
         @testset "progress" begin
             url = "https://httpbingo.org/drip"
             progress = []


### PR DESCRIPTION
This puts a total timeout on how long a request can take using the `CURLOPT_TIMEOUT_MS` or `CURLOPT_TIMEOUT` libcurl options. Closes https://github.com/JuliaLang/Downloads.jl/issues/70.
