### PR TITLE
fix the SYSTEM_SSL check for Windows

### DIFF
--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -41,7 +41,7 @@ end
 const CURL_VERSION_INFO = unsafe_load(curl_version_info(CURLVERSION_NOW))
 const SSL_VERSION = unsafe_string(CURL_VERSION_INFO.ssl_version)
 const SYSTEM_SSL =
-    Sys.isapple() && startswith(SSL_VERSION, "SecureTranspart")
+    Sys.isapple() && startswith(SSL_VERSION, "SecureTranspart") ||
     Sys.iswindows() && startswith(SSL_VERSION, "Schannel")
 
 const CURL_VERSION = unsafe_string(curl_version())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,12 @@
 include("setup.jl")
 
 @testset "Downloads.jl" begin
+    @testset "libcurl configuration" begin
+        if VERSION > v"1.6-"
+            @test Curl.SYSTEM_SSL == Sys.iswindows() || Sys.isapple()
+        end
+    end
+
     @testset "API coverage" begin
         value = "Julia is great!"
         base64 = "SnVsaWEgaXMgZ3JlYXQh"


### PR DESCRIPTION
Missing `||` in a multi-line conditional.