### PR TITLE
send user agent starting with "curl/"

### DIFF
--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -44,8 +44,14 @@ const SYSTEM_SSL =
     Sys.isapple() && startswith(SSL_VERSION, "SecureTranspart") ||
     Sys.iswindows() && startswith(SSL_VERSION, "Schannel")
 
-const CURL_VERSION = unsafe_string(curl_version())
-const USER_AGENT = "$CURL_VERSION julia/$VERSION"
+const CURL_VERSION_STR = unsafe_string(curl_version())
+let m = match(r"^libcurl/(\d+\.\d+\.\d+)\b", CURL_VERSION_STR)
+    m !== nothing || error("unexpected CURL_VERSION_STR value")
+    curl = m.captures[1]
+    julia = "$(VERSION.major).$(VERSION.minor)"
+    global const CURL_VERSION = VersionNumber(curl)
+    global const USER_AGENT = "curl/$curl julia/$julia"
+end
 
 include("Easy.jl")
 include("Multi.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ include("setup.jl")
 
 @testset "Downloads.jl" begin
     @testset "libcurl configuration" begin
+        julia = "$(VERSION.major).$(VERSION.minor)"
+        @test Curl.USER_AGENT == "curl/$(Curl.CURL_VERSION) julia/$julia"
         if VERSION > v"1.6-"
             @test Curl.SYSTEM_SSL == Sys.iswindows() || Sys.isapple()
         end
@@ -130,24 +132,28 @@ include("setup.jl")
                 @test header(json["headers"], key) == value
             end
             @test header(json["headers"], "Accept") == "*/*"
+            @test header(json["headers"], "User-Agent") == Curl.USER_AGENT
         end
 
         @testset "override default header" begin
             headers = ["Accept" => "application/tar"]
             json = download_json(url, headers = headers)
             @test header(json["headers"], "Accept") == "application/tar"
+            @test header(json["headers"], "User-Agent") == Curl.USER_AGENT
         end
 
         @testset "override default header with empty value" begin
             headers = ["Accept" => ""]
             json = download_json(url, headers = headers)
             @test header(json["headers"], "Accept") == ""
+            @test header(json["headers"], "User-Agent") == Curl.USER_AGENT
         end
 
         @testset "delete default header" begin
             headers = ["Accept" => nothing]
             json = download_json(url, headers = headers)
             @test !("Accept" in keys(json["headers"]))
+            @test header(json["headers"], "User-Agent") == Curl.USER_AGENT
         end
     end
 


### PR DESCRIPTION
See https://github.com/JuliaLang/Pkg.jl/issues/2290. Specifically this line of reasoning: Even though our agent isn't `curl` exactly, it is implemented using `libcurl`, and if the server behaves as though `curl` were making the request, that's probably generally going to work as well as possible.
