### PR TITLE
temporary fix for Pkg CI: only use HTTP/1.1

### DIFF
--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -49,6 +49,7 @@ function set_defaults(easy::Easy)
     @check curl_easy_setopt(easy.handle, CURLOPT_MAXREDIRS, 50)
     @check curl_easy_setopt(easy.handle, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL)
     @check curl_easy_setopt(easy.handle, CURLOPT_USERAGENT, USER_AGENT)
+    @check curl_easy_setopt(easy.handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1)
 end
 
 function set_ca_roots_path(easy::Easy, path::AbstractString)


### PR DESCRIPTION
See https://github.com/JuliaLang/Pkg.jl/pull/2357 for the problem. This is a temporary fix until I can add an option to NetworkOptions that allow us to properly control which hosts we use HTTP/2 for.