### PR TITLE
If the server transmits nothing for 20s, just bail out

### DIFF
--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -49,7 +49,11 @@ function set_defaults(easy::Easy)
     @check curl_easy_setopt(easy.handle, CURLOPT_MAXREDIRS, 50)
     @check curl_easy_setopt(easy.handle, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL)
     @check curl_easy_setopt(easy.handle, CURLOPT_USERAGENT, USER_AGENT)
+    # github's HTTP/2 handling is buggy, so just don't for now
     @check curl_easy_setopt(easy.handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1)
+    # if the server transmits nothing for 20s, just bail out
+    @check curl_easy_setopt(easy.handle, CURLOPT_LOW_SPEED_LIMIT, 1)
+    @check curl_easy_setopt(easy.handle, CURLOPT_LOW_SPEED_TIME, 20)
 end
 
 function set_ca_roots_path(easy::Easy, path::AbstractString)


### PR DESCRIPTION
See https://github.com/JuliaLang/Pkg.jl/issues/2337 — pkg servers have issues with hanging for some requests which affects pkg clients quite badly unless this is set. But it's generally a good idea to not wait forever when the data is not sending any data for substantial durations.