### PR TITLE
setopt: DRY out repetitive calls to curl_{easy,multi}_setopt

### DIFF
--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -63,4 +63,9 @@ function with_handle(f, handle::Union{Multi, Easy})
     end
 end
 
+setopt(easy::Easy, option::Integer, value) =
+    @check curl_easy_setopt(easy.handle, option, value)
+setopt(multi::Multi, option::Integer, value) =
+    @check curl_multi_setopt(multi.handle, option, value)
+
 end # module

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -204,12 +204,12 @@ function add_callbacks(multi::Multi)
 
     # set timer callback
     timer_cb = @cfunction(timer_callback, Cint, (Ptr{Cvoid}, Clong, Ptr{Cvoid}))
-    @check curl_multi_setopt(multi.handle, CURLMOPT_TIMERFUNCTION, timer_cb)
-    @check curl_multi_setopt(multi.handle, CURLMOPT_TIMERDATA, multi_p)
+    setopt(multi, CURLMOPT_TIMERFUNCTION, timer_cb)
+    setopt(multi, CURLMOPT_TIMERDATA, multi_p)
 
     # set socket callback
     socket_cb = @cfunction(socket_callback,
         Cint, (Ptr{Cvoid}, curl_socket_t, Cint, Ptr{Cvoid}, Ptr{Cvoid}))
-    @check curl_multi_setopt(multi.handle, CURLMOPT_SOCKETFUNCTION, socket_cb)
-    @check curl_multi_setopt(multi.handle, CURLMOPT_SOCKETDATA, multi_p)
+    setopt(multi, CURLMOPT_SOCKETFUNCTION, socket_cb)
+    setopt(multi, CURLMOPT_SOCKETDATA, multi_p)
 end


### PR DESCRIPTION
Some of these calls had gotten a bit lengthy and there are a lot of them so factoring out some of the repetetive boilerplate seems worthwhile.