### PR TITLE
test for sending user agent with each request

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,6 +164,17 @@ include("setup.jl")
             @test !("Accept" in keys(json["headers"]))
             @test !("User-Agent" in keys(json["headers"]))
         end
+
+        @testset "HTTP/2 user agent bug" begin
+            json = download_json(url, verbose = true)
+            @test header(json["headers"], "User-Agent") == Curl.USER_AGENT
+            @sync for _ = 1:2
+                @async begin
+                    json = download_json(url, verbose = true)
+                    @test header(json["headers"], "User-Agent") == Curl.USER_AGENT
+                end
+            end
+        end
     end
 
     @testset "file protocol" begin

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -4,6 +4,7 @@ using Downloads
 using Downloads: download
 using Downloads.Curl
 using Downloads.Curl: contains
+using Base.Experimental: @sync
 
 include("json.jl")
 


### PR DESCRIPTION
Real test for https://github.com/JuliaLang/Downloads.jl/pull/88. This currently doesn't test much since our httpbingo.julialang.org doesn't support HTTP/2 but I've tested it with httpbingo.org, which does, and without the fix in #88 and without forcing HTTP/1.1 this does fail.