### PR TITLE
unverified HTTPS: don't set CURLOPT_SSL_VERIFYHOST=0

### DIFF
--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -76,7 +76,6 @@ set_url(easy::Easy, url::AbstractString) = set_url(easy, String(url))
 
 function set_ssl_verify(easy::Easy, verify::Bool)
     setopt(easy, CURLOPT_SSL_VERIFYPEER, verify)
-    setopt(easy, CURLOPT_SSL_VERIFYHOST, verify*2)
 end
 
 function set_ssh_verify(easy::Easy, verify::Bool)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -403,13 +403,14 @@ include("setup.jl")
         end
     end
 
+    save_env = get(ENV, "JULIA_SSL_NO_VERIFY_HOSTS", nothing)
+    delete!(ENV, "JULIA_SSL_NO_VERIFY_HOSTS")
+
     @testset "bad TLS" begin
-        save_env = get(ENV, "JULIA_SSL_NO_VERIFY_HOSTS", nothing)
         urls = [
             "https://wrong.host.badssl.com"
             "https://untrusted-root.badssl.com"
         ]
-        ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = nothing
         @testset "bad TLS is rejected" for url in urls
             resp = request(url, throw=false)
             @test resp isa RequestError
@@ -449,11 +450,13 @@ include("setup.jl")
             @test resp isa Response
             @test resp.status == 200
         end
-        if save_env !== nothing
-            ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = save_env
-        else
-            delete!(ENV, "JULIA_SSL_NO_VERIFY_HOSTS")
-        end
+        delete!(ENV, "JULIA_SSL_NO_VERIFY_HOSTS")
+    end
+
+    if save_env !== nothing
+        ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = save_env
+    else
+        delete!(ENV, "JULIA_SSL_NO_VERIFY_HOSTS")
     end
 
     @__MODULE__() == Main && @testset "ftp download" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -453,6 +453,19 @@ include("setup.jl")
         delete!(ENV, "JULIA_SSL_NO_VERIFY_HOSTS")
     end
 
+    @testset "SNI required" begin
+        url = "https://juliahub.com" # anything served by CloudFront
+        # secure verified host request
+        resp = request(url, throw=false, downloader=Downloader())
+        @test resp isa Response
+        @test resp.status == 200
+        # insecure unverified host request
+        ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = "**"
+        resp = request(url, throw=false, downloader=Downloader())
+        @test resp isa Response
+        @test resp.status == 200
+    end
+
     if save_env !== nothing
         ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = save_env
     else


### PR DESCRIPTION
In https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html under "Limitations", it is documented that when `CURLOPT_SSL_VERIFYHOST` is set to zero this also turns off SNI (Server Name Indication):

> Secure Transport: If verify value is 0, then SNI is also disabled. SNI is a TLS extension that sends the hostname to the server. The server may use that information to do such things as sending back a specific certificate for the hostname, or forwarding the request to a specific origin server. Some hostnames may be inaccessible if SNI is not sent.

Since SNI is required to make requests to some HTTPS servers, disabling SNI can break things. This change leaves host verification on and only turns peer verification off (i.e. CA chain checking). I have yet to find an example where turning host verification off is necessary.