### PR TITLE
set TLS option CURLSSLOPT_REVOKE_BEST_EFFORT

### DIFF
--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -29,6 +29,10 @@ using LibCURL
 using LibCURL: curl_off_t
 # not exported: https://github.com/JuliaWeb/LibCURL.jl/issues/87
 
+# constants that LibCURL should have but doesn't
+const CURLE_PEER_FAILED_VERIFICATION = 60
+const CURLSSLOPT_REVOKE_BEST_EFFORT = 1 << 3
+
 using NetworkOptions
 using Base: preserve_handle, unpreserve_handle
 

--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -51,6 +51,7 @@ function set_defaults(easy::Easy)
     setopt(easy, CURLOPT_USERAGENT, USER_AGENT)
     setopt(easy, CURLOPT_NETRC, CURL_NETRC_OPTIONAL)
     setopt(easy, CURLOPT_COOKIEFILE, "")
+    setopt(easy, CURLOPT_SSL_OPTIONS, CURLSSLOPT_REVOKE_BEST_EFFORT)
 
     # ssh-related options
     setopt(easy, CURLOPT_SSH_PRIVATE_KEYFILE, ssh_key_path())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -414,10 +414,7 @@ include("setup.jl")
         @testset "bad TLS is rejected" for url in urls
             resp = request(url, throw=false)
             @test resp isa RequestError
-            # FIXME: we should use Curl.CURLE_PEER_FAILED_VERIFICATION
-            # but LibCURL has gotten out of sync with curl and some
-            # of the constants are no longer correct; this is one
-            @test resp.code == 60
+            @test resp.code == Curl.CURLE_PEER_FAILED_VERIFICATION
         end
         @testset "easy hook work-around" begin
             local url


### PR DESCRIPTION
The Windows native TLS backend (Schannel) makes synchronous certificate revocation checks against a CRL server. For users behind a firewall, this server may be unreachable, causing the TLS connection to fail. The `CURLSSLOPT_REVOKE_BEST_EFFORT` option addresses precisely this situation, configuring Schannel to make a best effort revocation check but allowing the connection if the CRL server cannot be reached, as long as the certificate isn't already known to be revoked. This behavior matches the default revocation checking behavior on macOS (asynchronous best effort) and is strictly more secure than Linux where no CRL checking is done.

Since the typical advice in such situations is to disable TLS host verification entirely, this is an improvement in that with this option, so long as the client's system CA roots are configured correctly, host verification will work and at least local MITM attacks are prevented.

See [this discussion](https://discourse.julialang.org/t/julia-1-6-libcurl-firewall-download-issue-windows-schannel-certificate-revocation-check-failure/58021) where several Windows uses behind firewalls reported this issue.