### PR TITLE
add connect timeout; reinstate speed limit

### DIFF
--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -53,6 +53,13 @@ function set_defaults(easy::Easy)
     setopt(easy, CURLOPT_COOKIEFILE, "")
     setopt(easy, CURLOPT_SSL_OPTIONS, CURLSSLOPT_REVOKE_BEST_EFFORT)
 
+    # prevent downloads that hang forever:
+    # - timeout no response on connect (more than 30s)
+    # - if server transmits nothing for 20s, bail out
+    setopt(easy, CURLOPT_CONNECTTIMEOUT, 30)
+    setopt(easy, CURLOPT_LOW_SPEED_TIME, 20)
+    setopt(easy, CURLOPT_LOW_SPEED_LIMIT, 1)
+
     # ssh-related options
     setopt(easy, CURLOPT_SSH_PRIVATE_KEYFILE, ssh_key_path())
     setopt(easy, CURLOPT_SSH_PUBLIC_KEYFILE, ssh_pub_key_path())


### PR DESCRIPTION
- This adds a connection timeout of 30 seconds, closing #125
- It re-instates the lower speed limit that was briefly added in #85 and was accidentally reverted in the following pull request (#86)

In combination, this should prevent downloads from hanging, whether because the server is unavailable and so the connection is never established, or because the server never sends any data after the connection is established. This does not put an absolute timeout on downloads since a very large download can take arbitrarily long while still making progress.
