### PR TITLE
Compatibility with LibCURL's new generator script

### DIFF
--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -29,10 +29,6 @@ using LibCURL
 using LibCURL: curl_off_t
 # not exported: https://github.com/JuliaWeb/LibCURL.jl/issues/87
 
-# constants that LibCURL should have but doesn't
-const CURLE_PEER_FAILED_VERIFICATION = 60
-const CURLSSLOPT_REVOKE_BEST_EFFORT = 1 << 3
-
 using NetworkOptions
 using Base: preserve_handle, unpreserve_handle
 
@@ -68,8 +64,14 @@ function with_handle(f, handle::Union{Multi, Easy})
 end
 
 setopt(easy::Easy, option::Integer, value) =
-    @check curl_easy_setopt(easy.handle, option, value)
+    @check curl_easy_setopt(easy.handle, CURLoption(option), value)
 setopt(multi::Multi, option::Integer, value) =
-    @check curl_multi_setopt(multi.handle, option, value)
+    @check curl_multi_setopt(multi.handle, CURLMoption(option), value)
+
+# CEnum is no longer Integer in LibCURL.jl
+setopt(easy::Easy, option::CURLoption, value) = setopt(easy, Int(option), value)
+setopt(multi::Multi, option::CURLMoption, value) = setopt(multi, Int(option), value)
+Base.zero(::CURLcode) = CURLE_OK
+Base.zero(::CURLMcode) = CURLM_OK
 
 end # module

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -230,7 +230,7 @@ function download(
             downloader = downloader,
         )
         status_ok(response.proto, response.status) && return output
-        throw(RequestError(url, Curl.CURLE_OK, "", response))
+        throw(RequestError(url, Int(Curl.CURLE_OK), "", response))
     end
 end
 
@@ -365,7 +365,7 @@ function request(
                 response = Response(get_response_info(easy)...)
                 easy.code == Curl.CURLE_OK && return response
                 message = get_curl_errstr(easy)
-                response = RequestError(url, easy.code, message, response)
+                response = RequestError(url, Int(easy.code), message, response)
                 throw && Base.throw(response)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -275,7 +275,7 @@ include("setup.jl")
 
         err = @exception download("$server/status/404")
         @test err isa RequestError
-        @test err.code == 0 && isempty(err.message)
+        @test err.code == Int(Curl.CURLE_OK) && isempty(err.message)
         @test err.response.status == 404
         @test contains(err.response.message, r"^HTTP/\d+(?:\.\d+)?\s+404\b")
         @test err.response.proto === "https"
@@ -414,7 +414,7 @@ include("setup.jl")
         @testset "bad TLS is rejected" for url in urls
             resp = request(url, throw=false)
             @test resp isa RequestError
-            @test resp.code == Curl.CURLE_PEER_FAILED_VERIFICATION
+            @test resp.code == Int(Curl.CURLE_PEER_FAILED_VERIFICATION)
         end
         @testset "easy hook work-around" begin
             local url


### PR DESCRIPTION
Ref: [LibCURL.jl#102](https://github.com/JuliaWeb/LibCURL.jl/pull/102)
I have tested this new wrapper, and Downloads.jl does not work with the new wrapper, mainly because:
* Enum types were mapped directly to integers in LibCURLjl, and hardcoded to `Integer` in Downloads.jl
* LibCURL.jl's constants are out of sync

this patch adds compatibility to the new wrapper. Most tests are passed, except the ones that can not be run on my network (`curl https://httpbingo.julialang.org/base64/SnVsaWEgaXMgZ3JlYXQh` returns `curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to httpbingo.julialang.org:443` without a proxy, for example)