### PR TITLE
Simplify lock(DOWNLOAD_LOCK)

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -290,9 +290,9 @@ function request(
     throw      :: Bool = true,
     downloader :: Union{Downloader, Nothing} = nothing,
 ) :: Union{Response, RequestError}
-    yield() # let other downloads finish
     if downloader === nothing
         lock(DOWNLOAD_LOCK) do
+            yield() # let other downloads finish
             downloader = DOWNLOADER[]
             if downloader === nothing
                 downloader = DOWNLOADER[] = Downloader()

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -290,13 +290,13 @@ function request(
     throw      :: Bool = true,
     downloader :: Union{Downloader, Nothing} = nothing,
 ) :: Union{Response, RequestError}
-    lock(DOWNLOAD_LOCK) do
-        yield() # let other downloads finish
-        downloader isa Downloader && return
-        while true
+    yield() # let other downloads finish
+    if downloader === nothing
+        lock(DOWNLOAD_LOCK) do
             downloader = DOWNLOADER[]
-            downloader isa Downloader && return
-            DOWNLOADER[] = Downloader()
+            if downloader === nothing
+                downloader = DOWNLOADER[] = Downloader()
+            end
         end
     end
     local response

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -305,7 +305,6 @@ function request(
 ) :: Union{Response, RequestError}
     if downloader === nothing
         lock(DOWNLOAD_LOCK) do
-            yield() # let other downloads finish
             downloader = DOWNLOADER[]
             if downloader === nothing
                 downloader = DOWNLOADER[] = Downloader()


### PR DESCRIPTION
This snippet was brought up in https://julialang.zulipchat.com/#narrow/stream/236830-concurrency/topic/Concurrency.20question.20in.20Downloads.2Ejl.

I only looked at the code mostly locally so I may be missing something, but, the `while` loop seems to be unnecessary since, in particular, no other part of the code sets `DOWNLOADER[]` (aside from the tests). Also, I couldn't find the reason why calling `yield` while holding a lock (it could just increase the number of tasks in the waiter list of the lock). So, I suggest calling it ouside.

(Aside: This code style as-is decreases inferrability of the `downloader` variable. But I chose this style to match with other parts of the code, to emphasize the clarify.)
