### PR TITLE
Fix input body size detection for `IOBuffer(codeunits(str))`

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -391,7 +391,7 @@ end
 p_func(progress::Nothing, input::ArgRead, output::ArgWrite) = nothing
 
 arg_read_size(path::AbstractString) = filesize(path)
-arg_read_size(io::IOBuffer) = io.size - io.ptr + 1
+arg_read_size(io::Base.GenericIOBuffer) = bytesavailable(io)
 arg_read_size(::Base.DevNull) = 0
 arg_read_size(::Any) = nothing
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -506,6 +506,14 @@ include("setup.jl")
         Downloads.download("https://httpbingo.org/drip"; downloader=dl)
         Downloads.download("https://httpbingo.org/drip"; downloader=dl)
     end
+
+    @testset "Input body size" begin
+        # Test mechanism to detect the body size from the request(; input) argument
+        @test Downloads.arg_read_size(@__FILE__) == filesize(@__FILE__)
+        @test Downloads.arg_read_size(IOBuffer("αa")) == 3
+        @test Downloads.arg_read_size(IOBuffer(codeunits("αa"))) == 3  # Issue #142
+        @test Downloads.arg_read_size(devnull) == 0
+    end
 end
 
 Downloads.DOWNLOADER[] = nothing


### PR DESCRIPTION
Somewhat surprisingly, the type of `IOBuffer(codeunits(str))` is not `IOBuffer`, but a related type (`Base.GenericIOBuffer{Base.CodeUnits{UInt8, String}}`).

Fixes #142

Generally I wonder if we should go further here? For instance, detecting the length of open files (`IOStream`) using a combination of `position` and `filesize`. It's kind of a mess though; I don't think there's a generic and reliable way to do this.

The downside of returning `nothing` is that some services require `Content-Length` to be set, as I found out for S3 PutObject through a rather baffling set of events in #142. If we return `nothing` for `arg_read_size()` we instead get `Transfer-Encoding: chunked` set by libcurl.