### PR TITLE
fix tests for httpbingo upgrade

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -335,7 +335,7 @@ include("setup.jl")
 
     @testset "request API" begin
         @testset "basic request usage" begin
-            for status in (200, 300, 400)
+            for status in [200, 400, 404]
                 url = "$server/status/$status"
                 resp, body = request_body(url)
                 @test resp.url == url


### PR DESCRIPTION
This test started failing because httpbingo now serves a 300 response with a location header, which gets followed so the response object ends up being a 200 OK instead of the expected 300. This changes the test to use 200, 400 and 404, which should never redirect.
