### PR TITLE
rectify control of easy-handle callbacks

### DIFF
--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -1,7 +1,7 @@
 mutable struct Easy
     handle   :: Ptr{Cvoid}
     input    :: IO
-    ready    :: Threads.Event
+    done     :: Threads.Event
     seeker   :: Union{Function,Nothing}
     output   :: IO
     progress :: Function

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -85,7 +85,7 @@ function check_multi_info(multi::Multi)
             easy = unsafe_pointer_to_objref(easy_p_ref[])::Easy
             @assert easy_handle == easy.handle
             easy.code = message.code
-            notify(easy.ready)
+            notify(easy.done)
         else
             @async @error("curl_multi_info_read: unknown message", message)
         end

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -343,10 +343,8 @@ function request(
 
                 # do the request
                 add_handle(downloader.multi, easy)
-                try wait(easy.ready) # can this throw?
-                finally
-                    remove_handle(downloader.multi, easy)
-                end
+                wait(easy.done)
+                remove_handle(downloader.multi, easy)
 
                 # return the response or throw an error
                 response = Response(get_response_info(easy)...)


### PR DESCRIPTION
This PR changes the complex easy handle callback flow to a more straightforward version where we register actual callbacks (or IO objects to read from or write to) with the `Easy` objects, which are then directly used in the easy handle callbacks. The steps:

- rectify control of progress callback
- rectify control of write callback
- rectify control of read callback
- rename easy.{ready => done}

There are a few issues with this though:

1. When an easy-handle callback blocks, it now blocks any progress on anything the multi-handle is working on, even for other downloads.

2. If the `Easy` type isn't parametric then its `input`, `output` and `progress` fields are abstract, which may cause performance issues. We can fix this by making `Easy` parametric, but that may lead to excess compilation and specialization.

The first point wasn't an issue with the old, convoluted version of the callbacks because the easy handle callbacks were designed to never block. The second point wasn't an issue because the callbacks always did the same thing and the variation in types was isolated to the `request` function, which would be specialized on different argument types, which would, of course cause specialization, but at least that was contained to one function.

So, overall, it's unclear that this is an improvement. The main issue with the status quo is that the `output` and `progress` channels can grow unbounded, but in practice that seems unlikely to be a real issue.
