### PR TITLE
should also look into headers for input_size

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -400,7 +400,7 @@ arg_read_size(::Base.DevNull) = 0
 arg_read_size(::Any) = nothing
 
 function content_length(headers::Union{AbstractVector, AbstractDict})
-    for (key,value) in headers
+    for (key, value) in headers
         if lowercase(key) == "content-length" && isa(value, AbstractString)
             return tryparse(Int, value)
         end

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -400,9 +400,9 @@ arg_read_size(::Base.DevNull) = 0
 arg_read_size(::Any) = nothing
 
 function content_length(headers::Union{AbstractVector, AbstractDict})
-    for kv in headers
-        if lowercase(kv[1]) == "content-length" && isa(kv[2], AbstractString)
-            return tryparse(Int, kv[2])
+    for (key,value) in headers
+        if lowercase(key) == "content-length" && isa(value, AbstractString)
+            return tryparse(Int, value)
         end
     end
     return nothing

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -305,6 +305,10 @@ function request(
     input = something(input, devnull)
     output = something(output, devnull)
     input_size = arg_read_size(input)
+    if input_size === nothing
+        # take input_size from content-length header is one is supplied
+        input_size = content_length(headers)
+    end
     progress = p_func(progress, input, output)
     arg_read(input) do input
         arg_write(output) do output
@@ -394,5 +398,14 @@ arg_read_size(path::AbstractString) = filesize(path)
 arg_read_size(io::Base.GenericIOBuffer) = bytesavailable(io)
 arg_read_size(::Base.DevNull) = 0
 arg_read_size(::Any) = nothing
+
+function content_length(headers)
+    for kv in headers
+        if lowercase(kv[1]) == "content-length" && isa(kv[2], AbstractString)
+            return tryparse(Int, kv[2])
+        end
+    end
+    return nothing
+end
 
 end # module

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -306,7 +306,7 @@ function request(
     output = something(output, devnull)
     input_size = arg_read_size(input)
     if input_size === nothing
-        # take input_size from content-length header is one is supplied
+        # take input_size from content-length header if one is supplied
         input_size = content_length(headers)
     end
     progress = p_func(progress, input, output)

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -399,7 +399,7 @@ arg_read_size(io::Base.GenericIOBuffer) = bytesavailable(io)
 arg_read_size(::Base.DevNull) = 0
 arg_read_size(::Any) = nothing
 
-function content_length(headers)
+function content_length(headers::Union{AbstractVector, AbstractDict})
     for kv in headers
         if lowercase(kv[1]) == "content-length" && isa(kv[2], AbstractString)
             return tryparse(Int, kv[2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -513,6 +513,8 @@ include("setup.jl")
         @test Downloads.arg_read_size(IOBuffer("αa")) == 3
         @test Downloads.arg_read_size(IOBuffer(codeunits("αa"))) == 3  # Issue #142
         @test Downloads.arg_read_size(devnull) == 0
+        @test Downloads.content_length(["Accept"=>"*/*",]) === nothing
+        @test Downloads.content_length(["Accept"=>"*/*", "Content-Length"=>"100"]) == 100
     end
 end
 


### PR DESCRIPTION
If no content length is set while uploading some contents, Curl defaults to use chunked transfer encoding. In some cases we want to prevent that because the server may not be supporting chunked transfers (and we already know the size).

With this change, the request method will also look at the headers while determining the input size and if found call `set_upload_size` as usual. So to switch off chunked transfers, one must also know and set the content length header while invoking `download` or `request` methods.