### PR TITLE
end-to-end tests for #167

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Julia 1.3 through 1.5 as well.
 
 The public API of `Downloads` consists of two functions and three types:
 
-- `download` — download a file from a URL, erroring if it can't be downloaded
+- `download` — download a file from a URL, erroring if it can't be downloaded
 - `request` — request a URL, returning a `Response` object indicating success
-- `Response` — a type capturing the status and other metadata about a request
-- `RequestError` — an error type thrown by `download` and `request` on error
+- `Response` — a type capturing the status and other metadata about a request
+- `RequestError` — an error type thrown by `download` and `request` on error
 - `Downloader` — an object encapsulating shared resources for downloading
 
 ### download
@@ -31,6 +31,7 @@ download(url, [ output = tempfile() ];
     [ timeout = <none>, ]
     [ progress = <none>, ]
     [ verbose = false, ]
+    [ debug = <none>, ]
     [ downloader = <default>, ]
 ) -> output
 ```
@@ -41,6 +42,7 @@ download(url, [ output = tempfile() ];
 - `timeout    :: Real`
 - `progress   :: (total::Integer, now::Integer) --> Any`
 - `verbose    :: Bool`
+- `debug      :: (type, message) --> Any`
 - `downloader :: Downloader`
 
 Download a file from the given url, saving it to `output` or if not specified, a
@@ -71,8 +73,14 @@ remains zero until the server gives an indication of the total size of the
 download (e.g. with a `Content-Length` header), which may never happen. So a
 well-behaved progress callback should handle a total size of zero gracefully.
 
-If the `verbose` optoin is set to true, `libcurl`, which is used to implement
-the download functionality will print debugging information to `stderr`.
+If the `verbose` option is set to true, `libcurl`, which is used to implement
+the download functionality will print debugging information to `stderr`. If the
+`debug` option is set to a function accepting two `String` arguments, then the
+verbose option is ignored and instead the data that would have been printed to
+`stderr` is passed to the `debug` callback with `type` and `message` arguments.
+The `type` argument indicates what kind of event has occurred, and is one of:
+`TEXT`, `HEADER IN`, `HEADER OUT`, `DATA IN`, `DATA OUT`, `SSL DATA IN` or `SSL
+DATA OUT`. The `message` argument is the description of the debug event.
 
 ### request
 
@@ -85,6 +93,7 @@ request(url;
     [ timeout = <none>, ]
     [ progress = <none>, ]
     [ verbose = false, ]
+    [ debug = <none>, ]
     [ throw = true, ]
     [ downloader = <default>, ]
 ) -> Union{Response, RequestError}
@@ -97,6 +106,7 @@ request(url;
 - `timeout    :: Real`
 - `progress   :: (dl_total, dl_now, ul_total, ul_now) --> Any`
 - `verbose    :: Bool`
+- `debug      :: (type, message) --> Any`
 - `throw      :: Bool`
 - `downloader :: Downloader`
 

--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -6,6 +6,7 @@ export
         set_url,
         set_method,
         set_verbose,
+        set_debug,
         set_body,
         set_upload_size,
         set_seeker,

--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -116,7 +116,7 @@ function set_upload_size(easy::Easy, size::Integer)
 end
 
 function set_seeker(seeker::Function, easy::Easy)
-    add_seek_callbacks(easy)
+    add_seek_callback(easy)
     easy.seeker = seeker
 end
 
@@ -159,7 +159,7 @@ function enable_progress(easy::Easy, on::Bool=true)
 end
 
 function enable_upload(easy::Easy)
-    add_upload_callbacks(easy::Easy)
+    add_upload_callback(easy::Easy)
     setopt(easy, CURLOPT_UPLOAD, true)
 end
 
@@ -404,7 +404,7 @@ function add_callbacks(easy::Easy)
     setopt(easy, CURLOPT_XFERINFODATA, easy_p)
 end
 
-function add_upload_callbacks(easy::Easy)
+function add_upload_callback(easy::Easy)
     # pointer to easy object
     easy_p = pointer_from_objref(easy)
 
@@ -415,7 +415,7 @@ function add_upload_callbacks(easy::Easy)
     setopt(easy, CURLOPT_READDATA, easy_p)
 end
 
-function add_seek_callbacks(easy::Easy)
+function add_seek_callback(easy::Easy)
     # pointer to easy object
     easy_p = pointer_from_objref(easy)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,6 +195,22 @@ include("setup.jl")
         end
     end
 
+    @testset "debug callback" begin
+        url = "$server/get"
+        events = Pair{String,String}[]
+        resp = request(url, debug = (type, msg) -> push!(events, type => msg))
+        @test resp isa Response && resp.status == 200
+        @test any(events) do (type, msg)
+            type == "TEXT" && startswith(msg, "Connected to ")
+        end
+        @test any(events) do (type, msg)
+            type == "HEADER OUT" && contains(msg, r"^HEAD /get HTTP/[\d\.+]+\s$"m)
+        end
+        @test any(events) do (type, msg)
+            type == "HEADER IN" && contains(msg, r"^HTTP/[\d\.]+ 200 OK\s*$")
+        end
+    end
+
     @testset "session support" begin
         downloader = Downloader()
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -60,10 +60,10 @@ end
 # URL escape & unescape
 
 function is_url_safe_byte(byte::UInt8)
-    0x2d ≤ byte ≤ 0x2e ||
+    0x2d ≤ byte ≤ 0x2e ||
     0x30 ≤ byte ≤ 0x39 ||
-    0x41 ≤ byte ≤ 0x5a ||
-    0x61 ≤ byte ≤ 0x7a ||
+    0x41 ≤ byte ≤ 0x5a ||
+    0x61 ≤ byte ≤ 0x7a ||
     byte == 0x5f ||
     byte == 0x7e
 end


### PR DESCRIPTION
This adds end-to-end tests for the changes introduced in #167.

Verbose mode is switched off for these tests, but switching it on would show that not setting content-length headers results in chunked transfer encoding while setting it prevents that. Both tests should pass.

fixes #169 