### PR TITLE
Revert "Use self-hosted `badssl.julialang.org` server"

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -469,8 +469,8 @@ include("setup.jl")
 
     @testset "bad TLS" begin
         urls = [
-            "https://untrusted-root.badssl.julialang.org"
-            "https://wrong.host.badssl.julialang.org"
+            "https://untrusted-root.badssl.com"
+            "https://wrong.host.badssl.com"
         ]
         @testset "bad TLS is rejected" for url in urls
             resp = request(url, throw=false)
@@ -504,7 +504,7 @@ include("setup.jl")
             Downloads.DOWNLOADER[] = nothing
             Downloads.EASY_HOOK[] = nothing
         end
-        ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = "**.badssl.julialang.org"
+        ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = "**.badssl.com"
         # wrong host *should* still fail, but may not due
         # to libcurl bugs when using non-OpenSSL backends:
         pop!(urls) # <= skip wrong host URL entirely here


### PR DESCRIPTION
Reverts JuliaLang/Downloads.jl#176

See https://github.com/JuliaLang/julia/pull/44123 for context.