### PR TITLE
Use our own custom `badssl.julialang.org` implementation

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -468,9 +468,10 @@ include("setup.jl")
     delete!(ENV, "JULIA_SSL_NO_VERIFY_HOSTS")
 
     @testset "bad TLS" begin
+        badssl = "badssl.julialang.org"
         urls = [
-            "https://untrusted-root.badssl.com"
-            "https://wrong.host.badssl.com"
+            "https://untrusted-root.$(badssl)"
+            "https://wrong.host.$(badssl)"
         ]
         @testset "bad TLS is rejected" for url in urls
             resp = request(url, throw=false)
@@ -504,7 +505,7 @@ include("setup.jl")
             Downloads.DOWNLOADER[] = nothing
             Downloads.EASY_HOOK[] = nothing
         end
-        ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = "**.badssl.com"
+        ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = "**.$(badssl)"
         # wrong host *should* still fail, but may not due
         # to libcurl bugs when using non-OpenSSL backends:
         pop!(urls) # <= skip wrong host URL entirely here


### PR DESCRIPTION
Follow-up to #176 and #177.