### PR TITLE
error message: include string `RequestError`

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -130,7 +130,7 @@ struct RequestError <: Exception
 end
 
 function Base.showerror(io::IO, err::RequestError)
-    print(io, "$(error_message(err)) while requesting $(err.url)")
+    print(io, "RequestError: $(error_message(err)) while requesting $(err.url)")
 end
 
 function error_message(err::RequestError)


### PR DESCRIPTION
This is done in the example in `Base.showerror`: https://github.com/JuliaLang/julia/blob/2049baaf31edc75c4403177e21bb1c3be49fb683/base/errorshow.jl#L16

It would've been helpful for https://github.com/JuliaCloud/AWS.jl/issues/541 to understand what kind of error it is. E.g. if it's a RequestError, then it's already being retried and we must've hit the retry limit; if it wasn't a RequestError, it was likely uncaught and therefore we'd be missing a retry. Looking at it now, I am pretty sure it's a request error because it has the `X while requesting Y` format.