### PR TITLE
Add a `status_ok(response::Response)` method

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -97,6 +97,8 @@ struct Response
     headers :: Vector{Pair{String,String}}
 end
 
+Curl.status_ok(response::Response) = status_ok(response.proto, response.status)
+
 """
     struct RequestError <: ErrorException
         url      :: String
@@ -239,7 +241,7 @@ function download(
             debug = debug,
             downloader = downloader,
         )::Response
-        status_ok(response.proto, response.status) && return output
+        status_ok(response) && return output
         throw(RequestError(url, Curl.CURLE_OK, "", response))
     end
 end


### PR DESCRIPTION
I'd like to use `status_ok` in Pkg. It would be most convenient if I can just write `status_ok(response::Response)` and not have to worry about the internal layout of the `Response` struct.