### PR TITLE
add concurrent connection semaphore to prevent DNS resolve races

### DIFF
--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -33,6 +33,8 @@ using LibCURL: curl_off_t, libcurl
 # constants that LibCURL should have but doesn't
 const CURLE_PEER_FAILED_VERIFICATION = 60
 const CURLSSLOPT_REVOKE_BEST_EFFORT = 1 << 3
+const CURLOPT_PREREQFUNCTION = 20000 + 312
+const CURLOPT_PREREQDATA = 10000 + 313
 
 # these are incorrectly defined on Windows by LibCURL:
 if Sys.iswindows()

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -41,6 +41,7 @@ end
 # adding & removing easy handles
 
 function add_handle(multi::Multi, easy::Easy)
+    connect_semaphore_acquire(easy)
     lock(multi.lock) do
         if isempty(multi.easies)
             preserve_handle(multi)
@@ -70,6 +71,7 @@ function remove_handle(multi::Multi, easy::Easy)
         end
         unpreserve_handle(multi)
     end
+    connect_semaphore_release(easy)
 end
 
 # multi-socket options


### PR DESCRIPTION
The libcurl spawns a new thread for each DNS resolution that it needs to
do, which can cause problems when too many connections are started at
the same time. This adds a semaphore which is acqured when a connection
starts and gets released once the actual request starts. This limits the
number of concurrent requests that are in the connecting state to the
size of the semaphore (16). Hopefully this prevents the "getaddrinfo()
thread failed" errors that occur sometimes.
