### PR TITLE
Enable setting default Downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Julia 1.3 through 1.5 as well.
 
 ## API
 
-The public API of `Downloads` consists of two functions and three types:
+The public API of `Downloads` consists of three functions and three types:
 
 - `download` — download a file from a URL, erroring if it can't be downloaded
 - `request` — request a URL, returning a `Response` object indicating success
+- `default_downloader!` - set the default `Downloader` object
 - `Response` — a type capturing the status and other metadata about a request
 - `RequestError` — an error type thrown by `download` and `request` on error
 - `Downloader` — an object encapsulating shared resources for downloading
@@ -127,6 +128,18 @@ Note that unlike `download` which throws an error if the requested URL could not
 be downloaded (indicated by non-2xx status code), `request` returns a `Response`
 object no matter what the status code of the response is. If there is an error
 with getting a response at all, then a `RequestError` is thrown or returned.
+
+### default_downloader!
+
+```jl
+    default_downloader!(
+        downloader = <none>
+    ) 
+```
+- `downloader :: Downloader`
+
+Set the default `Downloader`. If no argument is provided, resets the default downloader 
+so that a fresh one is created the next time the default downloader is needed.
 
 ### Response
 

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -20,7 +20,7 @@ using ArgTools
 include("Curl/Curl.jl")
 using .Curl
 
-export download, request, Downloader, Response, RequestError
+export download, request, Downloader, Response, RequestError, default_downloader!
 
 ## public API types ##
 
@@ -421,6 +421,23 @@ function content_length(headers::Union{AbstractVector, AbstractDict})
         end
     end
     return nothing
+end
+
+"""
+    default_downloader!(
+        downloader = <none>
+    ) 
+
+        downloader :: Downloader
+
+Set the default `Downloader`. If no argument is provided, resets the default downloader so that a fresh one is created the next time the default downloader is needed.
+"""
+function default_downloader!(
+    downloader :: Union{Downloader, Nothing} = nothing
+)
+    lock(DOWNLOAD_LOCK) do
+        DOWNLOADER[] = downloader
+    end
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -253,6 +253,32 @@ include("setup.jl")
         @test isempty(cookies)
     end
 
+    @testset "default_downloader!" begin
+        original = Downloads.DOWNLOADER[]
+        try
+            tripped = false
+            url = "$server/get"
+
+            downloader = Downloader()
+            downloader.easy_hook = (easy, info) -> tripped = true
+
+            # set default
+            default_downloader!(downloader)
+            _ = download_body(url)
+            @test tripped
+
+            #reset tripwire
+            tripped = false
+
+            # reset default
+            default_downloader!()
+            _ = download_body(url)
+            @test !tripped
+        finally
+            Downloads.DOWNLOADER[] = original
+        end
+    end
+
     @testset "netrc support" begin
         user = "gVvkQiHN62"
         passwd = "dlctfSMTno8n"


### PR DESCRIPTION
This PR will allow setting the default `Downloader`.

Motivated by the discussion at JuliaLang/Pkg.jl#3211

## TODO
- [x] add tests
- [x] update documentation

## Request feedback on:
- function naming (currently `default_downloader!`
- Should this be part of the exported API?

  