### PR TITLE
Don't error if `CURL_VERSION_INFO.ssl_version` is NULL

### DIFF
--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -69,7 +69,11 @@ function __init__()
 end
 
 const CURL_VERSION_INFO = unsafe_load(curl_version_info(CURLVERSION_NOW))
-const SSL_VERSION = unsafe_string(CURL_VERSION_INFO.ssl_version)
+if CURL_VERSION_INFO.ssl_version == Base.C_NULL
+    const SSL_VERSION = ""
+else
+    const SSL_VERSION = unsafe_string(CURL_VERSION_INFO.ssl_version)::String
+end
 const SYSTEM_SSL =
     Sys.isapple() && startswith(SSL_VERSION, "SecureTransport") ||
     Sys.iswindows() && startswith(SSL_VERSION, "Schannel")


### PR DESCRIPTION
Fixes #216 
Fixes https://github.com/JuliaLang/julia/issues/48407