### PR TITLE
Adjust message matching

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,7 +228,7 @@ include("setup.jl")
         resp = request(url, debug = (type, msg) -> push!(events, type => msg))
         @test resp isa Response && resp.status == 200
         @test any(events) do (type, msg)
-            type == "TEXT" && startswith(msg, "Connected to ")
+            type == "TEXT" && startswith(msg, r"(Connected to |Connection.* left intact)")
         end
         @test any(events) do (type, msg)
             type == "HEADER OUT" && contains(msg, r"^HEAD /get HTTP/[\d\.+]+\s$"m)


### PR DESCRIPTION
Updating LibCURL_jll from 7.84.0 to 7.88.1 in https://github.com/JuliaLang/julia/pull/48800 makes tests fail semi-randomly, due to a message being shifted from:

```
msg = "Connected to httpbingo.julialang.org (54.164.225.123) port 443 (#0)\n"
```

to 

```
msg = "Connection #0 to host httpbingo.julialang.org left intact\n"
```

(see details in https://github.com/JuliaLang/julia/pull/48800#issuecomment-1445480741). This happens when the testset is run twice in the same session.