### PR TITLE
Allow specifying the username

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ download(url, [ output = tempname() ];
     [ verbose = false, ]
     [ debug = <none>, ]
     [ downloader = <default>, ]
+    [ username = <none>, ]
 ) -> output
 ```
 - `url        :: AbstractString`
@@ -45,6 +46,7 @@ download(url, [ output = tempname() ];
 - `verbose    :: Bool`
 - `debug      :: (type, message) --> Any`
 - `downloader :: Downloader`
+- `username   :: AbstractString`
 
 Download a file from the given url, saving it to `output` or if not specified, a
 temporary path. The `output` can also be an `IO` handle, in which case the body
@@ -97,6 +99,7 @@ request(url;
     [ debug = <none>, ]
     [ throw = true, ]
     [ downloader = <default>, ]
+    [ username = <none>, ]
 ) -> Union{Response, RequestError}
 ```
 - `url        :: AbstractString`
@@ -110,6 +113,7 @@ request(url;
 - `debug      :: (type, message) --> Any`
 - `throw      :: Bool`
 - `downloader :: Downloader`
+- `username   :: AbstractString`
 
 Make a request to the given url, returning a `Response` object capturing the
 status, headers and other information about the response. The body of the

--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -6,6 +6,7 @@ export
         set_url,
         set_method,
         set_verbose,
+        set_username,
         set_debug,
         set_body,
         set_upload_size,

--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -135,6 +135,10 @@ function set_verbose(easy::Easy, verbose::Bool)
     setopt(easy, CURLOPT_VERBOSE, verbose)
 end
 
+function set_username(easy::Easy, username::AbstractString)
+    setopt(easy, CURLOPT_USERNAME, username)
+end
+
 function set_debug(easy::Easy, debug::Function)
     hasmethod(debug, Tuple{String,String}) ||
         throw(ArgumentError("debug callback must take (::String, ::String)"))


### PR DESCRIPTION
Libcurl's SSH key-based and agent-based authentication methods don't work unless the username is set, either by including it in the URL or by setting `CURLOPT_USERNAME`. This PR adds a `username` keyword to the `download` and `request` functions to allow the user to optionally specify a username.

Related to this discourse discussion: https://discourse.julialang.org/t/privately-hosting-binarybuilder-products-with-authentication/88409