### PR TITLE
add a small precompile workload

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -465,4 +465,15 @@ function default_downloader!(
     end
 end
 
+# Precompile
+let
+    d = Downloader(; grace=0.01)
+    download("file://" * @__FILE__; downloader=d)
+    # Ref https://github.com/JuliaLang/julia/issues/49513
+    # we wait for the grace task to finish
+    sleep(0.05)
+    precompile(Tuple{typeof(Downloads.download), String, String})
+    precompile(Tuple{typeof(Downloads.Curl.status_2xx_ok), Int64})
+end
+
 end # module


### PR DESCRIPTION
Using 

```julia
@time @eval Downloads.download("https://pkg.julialang.org/registries", tempname())
```

as a test (because that is the end function I am interested in) we get on master:

```julia
0.838721 seconds (489.98 k allocations: 34.457 MiB, 41.40% compilation time)
```

and with this PR:

```julia
0.484503 seconds (31.97 k allocations: 2.184 MiB, 4.42% compilation time)
```

