### PR TITLE
Skip flakey "concurrent requests" tests on windows

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -379,25 +379,31 @@ include("setup.jl")
     end
 
     @testset "concurrent requests" begin
-        mine = Downloader()
-        for downloader in (nothing, mine)
-            have_lsof = Sys.which("lsof") !== nothing
-            count_tcp() = Base.count(x->contains("TCP",x), split(read(`lsof -p $(getpid())`, String), '\n'))
-            if have_lsof
-                n_tcp = count_tcp()
-            end
-            delay = 2
-            count = 100
-            url = "$server/delay/$delay"
-            t = @elapsed @sync for id = 1:count
-                @async begin
-                    json = download_json("$url?id=$id", downloader = downloader)
-                    @test get(json["args"], "id", nothing) == ["$id"]
+        if Sys.iswindows()
+            # Known issue https://github.com/JuliaLang/Downloads.jl/issues/227
+            # These test should be fixed on Windows and then reenabled.
+            @test_skip "concurrent requests flakey on Windows"
+        else
+            mine = Downloader()
+            for downloader in (nothing, mine)
+                have_lsof = Sys.which("lsof") !== nothing
+                count_tcp() = Base.count(x->contains("TCP",x), split(read(`lsof -p $(getpid())`, String), '\n'))
+                if have_lsof
+                    n_tcp = count_tcp()
                 end
-            end
-            @test t < 0.9*count*delay
-            if have_lsof
-                @test n_tcp == count_tcp()
+                delay = 2
+                count = 100
+                url = "$server/delay/$delay"
+                t = @elapsed @sync for id = 1:count
+                    @async begin
+                        json = download_json("$url?id=$id", downloader = downloader)
+                        @test get(json["args"], "id", nothing) == ["$id"]
+                    end
+                end
+                @test t < 0.9*count*delay
+                if have_lsof
+                    @test n_tcp == count_tcp()
+                end
             end
         end
     end


### PR DESCRIPTION
These tests are repeatedly causing Julia CI to fail. This PR skips them so folks submitting unrelated PRs don't have to go through test logs to make sure that failures are unrelated.

Failure on windows [f09e46d163](https://github.com/JuliaLang/julia/commit/f09e46d163f633da606271a07cceacb151e37da5): [buildkite](https://buildkite.com/julialang/julia-master/builds/24485#01887c4b-a593-4a4a-96f0-807845a73fa8/12484-13344)
Failure on windows [be2c35a8d2](https://github.com/JuliaLang/julia/commit/be2c35a8d2c29acdf9f250ba85f106bbac3dc143): [buildkite](https://buildkite.com/julialang/julia-master/builds/24483#01887c4a-460b-42cc-aec8-f35dd5db4906/12322-13247)
Failure on windows [318f0ead95](https://github.com/JuliaLang/julia/commit/318f0ead957a37e2898d71d457d7eab2a647bb13): [buildkite](https://buildkite.com/julialang/julia-master/builds/24392#01886e42-1211-488a-9f00-662abb7f7a04/12455-13317)
Reported: https://github.com/JuliaLang/Downloads.jl/issues/227
