### PR TITLE
Experiment: remove precompile workload

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -465,13 +465,4 @@ function default_downloader!(
     end
 end
 
-# Precompile
-let
-    d = Downloader()
-    f = mktemp()[1]
-    download("file://" * f; downloader=d)
-    precompile(Tuple{typeof(Downloads.download), String, String})
-    precompile(Tuple{typeof(Downloads.Curl.status_2xx_ok), Int64})
-end
-
 end # module


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/53403, I have the issue that this precompile workload errors during CI because of some weird reason with `mktemp`:

```
      From worker 2:	ERROR: LoadError: SystemError: mktemp: Operation not permitted
      From worker 2:	Stacktrace:
      From worker 2:	 [1] systemerror(p::Symbol, errno::Int32; extrainfo::Nothing)
      From worker 2:	   @ Base ./error.jl:176
      From worker 2:	 [2] systemerror
      From worker 2:	   @ ./error.jl:175 [inlined]
      From worker 2:	 [3] mktemp(parent::String; cleanup::Bool)
      From worker 2:	   @ Base.Filesystem ./file.jl:676
      From worker 2:	 [4] mktemp
      From worker 2:	   @ ./file.jl:673 [inlined]
      From worker 2:	 [5] mktemp()
      From worker 2:	   @ Base.Filesystem ./file.jl:673
      From worker 2:	 [6] top-level scope
      From worker 2:	   @ ~/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-master/julia-4a04df3954/share/julia/stdlib/v1.12/Downloads/src/Downloads.jl:471
```

This is to try out the PR without the workload. If it works, I am inclined to just remove this because the value of it is marginal at best.