### PR TITLE
fix: use invokelatest for easy_hook, avoid race

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -51,7 +51,8 @@ function grace_ms(grace::Real)
 end
 
 function easy_hook(downloader::Downloader, easy::Easy, info::NamedTuple)
-    downloader.easy_hook !== nothing && downloader.easy_hook(easy, info)
+    hook = downloader.easy_hook
+    hook !== nothing && Base.invokelatest(hook, easy, info)
 end
 
 get_ca_roots() = Curl.SYSTEM_SSL ? ca_roots() : ca_roots_path()


### PR DESCRIPTION
- uses `Base.invokelatest` while invoking `easy_hook` methods because the downloads instance and callbacks may be in different world ages.
- stores the `easy_hook` in local var to avoid races that cn happen between checking and invoking

fixes #240