### PR TITLE
register `atexit` hook on module `_init_`

### DIFF
--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -67,6 +67,7 @@ include("utils.jl")
 
 function __init__()
     @check curl_global_init(CURL_GLOBAL_ALL)
+    Base.atexit(atexit_close_multis)
 end
 
 const CURL_VERSION_INFO = unsafe_load(curl_version_info(CURLVERSION_NOW))

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -56,7 +56,7 @@ end
 const MULTIS_LOCK = Base.ReentrantLock()
 const MULTIS = WeakRef[]
 # Close any Multis and their timers at exit that haven't been finalized by then
-Base.atexit() do
+function atexit_close_multis()
     while true
         w = @lock MULTIS_LOCK (isempty(MULTIS) ? nothing : pop!(MULTIS))
         w === nothing && break


### PR DESCRIPTION
These hooks are usually registered at module `_init_`,
partially to make the code easier to reason about. Though
this now has greater significance with improved static
compilation techniques, since the _init_ is the module
entry and anything outside will be discarded from what
I can tell.
