### PR TITLE
only run precompile workload when generating output

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -466,7 +466,7 @@ function default_downloader!(
 end
 
 # Precompile
-let
+if Base.generating_output()
     d = Downloader()
     f = mktemp()[1]
     download("file://" * f; downloader=d)


### PR DESCRIPTION
otherwise we run code at module load each time.
