### PR TITLE
Attempt to make tests pass on FreeBSD

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -351,13 +351,13 @@ include("setup.jl")
         err = @exception download("https://domain.invalid")
         @test err isa RequestError
         @test err.code != 0
-        @test startswith(err.message, "Could not resolve host")
+        @test startswith(err.message, Sys.isfreebsd() ? "Resolving timed out" : "Could not resolve host")
         @test err.response.proto === nothing
 
         err = @exception request("https://domain.invalid", input = IOBuffer("Hi"))
         @test err isa RequestError
         @test err.code != 0
-        @test startswith(err.message, "Could not resolve host")
+        @test startswith(err.message, Sys.isfreebsd() ? "Resolving timed out" : "Could not resolve host")
         @test err.response.proto === nothing
 
         err = @exception download("$server/status/404")


### PR DESCRIPTION
With luck this will fix some failures I saw on freebsd: https://buildkite.com/julialang/julia-master/builds/38343#0190dc42-ca45-4f4c-a6bd-b3d380d210dd/717-1489

```julia
Test Failed at /usr/home/julia/.buildkite-agent/builds/freebsd13-amdci6-2/julialang/julia-master/julia-35e0d9cefc/share/julia/stdlib/v1.12/Downloads/test/runtests.jl:354
  Expression: startswith(err.message, "Could not resolve host")
   Evaluated: startswith("Resolving timed out after 30005 milliseconds", "Could not resolve host")
Error in testset Downloads:
Test Failed at /usr/home/julia/.buildkite-agent/builds/freebsd13-amdci6-2/julialang/julia-master/julia-35e0d9cefc/share/julia/stdlib/v1.12/Downloads/test/runtests.jl:360
  Expression: startswith(err.message, "Could not resolve host")
   Evaluated: startswith("Resolving timed out after 30002 milliseconds", "Could not resolve host")
```

I think ideally the timeout would be a bit shorter than 30s but I'm not sure how to change that.