### PR TITLE
Bump CI actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,17 @@ jobs:
             version: '1.3' # `curl_easy_setopt: 48` error on github CI
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - run: julia --color=yes .ci/test_and_change_uuid.jl
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
I noticed that some of the CI actions versions were out of date so I took the liberty of updating them.

I think an admin will need to add a `CODECOV_TOKEN` secret to the repo before this is merged because tokenless uploading is unsupported now: https://github.com/codecov/codecov-action?tab=readme-ov-file#breaking-changes
That might be why the last commit shown on codecov is from 5 months ago: https://app.codecov.io/gh/JuliaLang/Downloads.jl/commits