### PR TITLE
fix: handle FDWatcher exception on closed sockets

### DIFF
--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -190,6 +190,9 @@ function socket_callback(
                     rethrow()
                 end
             end
+            if watcher === nothing
+                return -1
+            end
             preserve_handle(watcher)
             watcher_p = pointer_from_objref(watcher)
             @check curl_multi_assign(multi.handle, sock, watcher_p)

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -398,7 +398,12 @@ function request(
                 add_handle_error = add_handle(downloader.multi, easy)
                 if add_handle_error != 0
                     no_response = Response(nothing, "", 0, "", [])
-                    throw(RequestError(url, add_handle_error, "", no_response))
+                    request_error = RequestError(url, add_handle_error, "", no_response)
+                    if throw
+                        Base.throw(request_error)
+                    else
+                        return request_error
+                    end
                 end
                 interrupted = Threads.Atomic{Bool}(false)
                 if interrupt !== nothing

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -395,7 +395,11 @@ function request(
                 easy_hook(downloader, easy, info)
 
                 # do the request
-                add_handle(downloader.multi, easy)
+                add_handle_error = add_handle(downloader.multi, easy)
+                if add_handle_error != 0
+                    no_response = Response(nothing, "", 0, "", [])
+                    throw(RequestError(url, add_handle_error, "", no_response))
+                end
                 interrupted = Threads.Atomic{Bool}(false)
                 if interrupt !== nothing
                     interrupt_task = @async begin


### PR DESCRIPTION
Adding checks to handle exception thrown while constructing FDWatcher if the socket handle is closed. Also checking the curl return code while adding handle to multi, and not proceeding if that failed.

Should fix #253