### PR TITLE
gracefully cancel a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ request(url;
     [ debug = <none>, ]
     [ throw = true, ]
     [ downloader = <default>, ]
+    [ interrupt = <none>, ]
 ) -> Union{Response, RequestError}
 ```
 - `url        :: AbstractString`
@@ -110,6 +111,7 @@ request(url;
 - `debug      :: (type, message) --> Any`
 - `throw      :: Bool`
 - `downloader :: Downloader`
+- `interrupt  :: Base.Event`
 
 Make a request to the given url, returning a `Response` object capturing the
 status, headers and other information about the response. The body of the
@@ -128,6 +130,11 @@ Note that unlike `download` which throws an error if the requested URL could not
 be downloaded (indicated by non-2xx status code), `request` returns a `Response`
 object no matter what the status code of the response is. If there is an error
 with getting a response at all, then a `RequestError` is thrown or returned.
+
+If the `interrupt` keyword argument is provided, it must be a `Base.Event` object.
+If the event is triggered while the request is in progress, the request will be
+cancelled and an error will be thrown. This can be used to interrupt a long
+running request, for example if the user wants to cancel a download.
 
 ### default_downloader!
 

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -201,6 +201,10 @@ function socket_callback(
                 end
             end
             @isdefined(errormonitor) && errormonitor(task)
+        else
+            lock(multi.lock) do
+                check_multi_info(multi)
+            end
         end
         @isdefined(old_watcher) && close(old_watcher)
         return 0

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -440,7 +440,13 @@ function request(
                 response = Response(get_response_info(easy)...)
                 easy.code == Curl.CURLE_OK && return response
                 message = get_curl_errstr(easy)
-                response = RequestError(url, easy.code, message, response)
+                if easy.code == typemax(Curl.CURLcode)
+                    # uninitialized code, likely a protocol error
+                    code = Int(0)
+                else
+                    code = Int(easy.code)
+                end
+                response = RequestError(url, code, message, response)
                 throw && Base.throw(response)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -468,6 +468,18 @@ include("setup.jl")
             end
         end
 
+        @testset "interrupt" begin
+            url = "$server/delay/10"
+            interrupt = Base.Event()
+            download_task = @async request(url; interrupt=interrupt)
+            sleep(0.1)
+            @test !istaskdone(download_task)
+            notify(interrupt)
+            timedwait(()->istaskdone(download_task), 5.0)
+            @test istaskdone(download_task)
+            @test download_task.result isa RequestError
+        end
+
         @testset "progress" begin
             url = "$server/drip"
             progress = []


### PR DESCRIPTION
Adds a way to gracefully cancel an ongoing request. The `request` method accepts an additional `interrupt` keyword which can be a `Base.Event`. When it is triggered, the [`curl_multi_remove_handle`](https://curl.se/libcurl/c/curl_multi_remove_handle.html) is invoked, which interrupts the easy handle gracefully. It closes the `output` and `progress` channels of the `Easy` handle to unblock the waiting request task, which then terminates with a `RequestError`.

Ref: #255