### PR TITLE
Fix setting atexit. Fixes trailing download tasks during precompilation

### DIFF
--- a/src/Curl/Curl.jl
+++ b/src/Curl/Curl.jl
@@ -65,10 +65,6 @@ using Base: OS_HANDLE, preserve_handle, unpreserve_handle
 
 include("utils.jl")
 
-function __init__()
-    @check curl_global_init(CURL_GLOBAL_ALL)
-end
-
 const CURL_VERSION_INFO = unsafe_load(curl_version_info(CURLVERSION_NOW))
 if CURL_VERSION_INFO.ssl_version == Base.C_NULL
     const SSL_VERSION = ""
@@ -90,6 +86,20 @@ end
 
 include("Easy.jl")
 include("Multi.jl")
+
+function __init__()
+    @check curl_global_init(CURL_GLOBAL_ALL)
+
+    # Close any Multis and their timers at exit that haven't been finalized by then
+    Base.atexit() do
+        while true
+            w = @lock MULTIS_LOCK (isempty(MULTIS) ? nothing : pop!(MULTIS))
+            w === nothing && break
+            w = w.value
+            w isa Multi && done!(w)
+        end
+    end
+end
 
 function with_handle(f, handle::Union{Multi, Easy})
     try f(handle)

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -55,15 +55,6 @@ end
 
 const MULTIS_LOCK = Base.ReentrantLock()
 const MULTIS = WeakRef[]
-# Close any Multis and their timers at exit that haven't been finalized by then
-Base.atexit() do
-    while true
-        w = @lock MULTIS_LOCK (isempty(MULTIS) ? nothing : pop!(MULTIS))
-        w === nothing && break
-        w = w.value
-        w isa Multi && done!(w)
-    end
-end
 
 function remove_handle(multi::Multi, easy::Easy)
     lock(multi.lock) do

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -468,6 +468,7 @@ end
 
 # Precompile
 let
+    Curl.__init__()
     d = Downloader()
     f = mktemp()[1]
     download("file://" * f; downloader=d)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Pkg.jl/issues/4004
Fixes https://github.com/JuliaLang/julia/issues/52685

```
% JULIA_DEPOT_PATH=$(mktemp -d): ./julia --start=no -e 'using Pkg; Pkg.add("MicroMamba");'
  Installing known registries into `/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/tmp.pCuLh8wMW6`
       Added `General` registry to /var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/tmp.pCuLh8wMW6/registries
    Updating registry at `/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/tmp.pCuLh8wMW6/registries/General.toml`
   Resolving package versions...
   Installed micromamba_jll ─ v1.5.8+0
   Installed MicroMamba ───── v0.1.14
   Installed JLLWrappers ──── v1.5.0
   Installed Scratch ──────── v1.2.1
   Installed Preferences ──── v1.4.3
    Updating `/private/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/tmp.pCuLh8wMW6/environments/v1.12/Project.toml`
  [0b3b1443] + MicroMamba v0.1.14
    Updating `/private/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/tmp.pCuLh8wMW6/environments/v1.12/Manifest.toml`
  [692b3bcd] + JLLWrappers v1.5.0
  [0b3b1443] + MicroMamba v0.1.14
  [21216c6a] + Preferences v1.4.3
  [6c6a2e73] + Scratch v1.2.1
  [f8abcde7] + micromamba_jll v1.5.8+0
  [0dad84c5] + ArgTools v1.1.2
  [56f22d72] + Artifacts v1.11.0
  [2a0f44e3] + Base64 v1.11.0
  [ade2ca70] + Dates v1.11.0
  [f43a241f] + Downloads v1.6.0
  [7b1f6079] + FileWatching v1.11.0
  [dc6e5ff7] + JuliaSyntaxHighlighting v1.12.0
  [4af54fe1] + LazyArtifacts v1.11.0
  [b27032c2] + LibCURL v0.6.4
  [76f85450] + LibGit2 v1.11.0
  [8f399da3] + Libdl v1.11.0
  [56ddb016] + Logging v1.11.0
  [d6f4376e] + Markdown v1.11.0
  [ca575930] + NetworkOptions v1.2.0
  [44cfe95a] + Pkg v1.12.0
  [de0858da] + Printf v1.11.0
  [9a3f8284] + Random v1.11.0
  [ea8e919c] + SHA v0.7.0
  [f489334b] + StyledStrings v1.11.0
  [fa267f1f] + TOML v1.0.3
  [a4e569a6] + Tar v1.10.0
  [cf7118a7] + UUIDs v1.11.0
  [4ec0a83e] + Unicode v1.11.0
  [deac9b47] + LibCURL_jll v8.6.0+0
  [e37daf67] + LibGit2_jll v1.8.0+0
  [29816b5a] + LibSSH2_jll v1.11.0+1
  [c8ffd9c3] + MbedTLS_jll v2.28.6+0
  [14a3606d] + MozillaCACerts_jll v2024.3.11
  [83775a58] + Zlib_jll v1.3.1+0
  [8e850ede] + nghttp2_jll v1.60.0+0
  [3f19e933] + p7zip_jll v17.5.0+0
Precompiling all packages...
  5 dependencies successfully precompiled in 6 seconds. 26 already precompiled.
  1 dependency had output during precompilation:
┌ micromamba_jll
│   Downloading artifact: micromamba
└  
```