### PR TITLE
fix cancelling upload requests

### DIFF
--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -375,7 +375,11 @@ function upload_data(easy::Easy, input::IO)
         curl_easy_pause(easy.handle, Curl.CURLPAUSE_CONT)
         wait(easy.ready)
         easy.input === nothing && break
-        easy.ready = Threads.Event()
+        if hasmethod(reset, (Base.Event,))
+            reset(easy.ready)
+        else
+            easy.ready = Threads.Event()
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -478,6 +478,17 @@ include("setup.jl")
             timedwait(()->istaskdone(download_task), 5.0)
             @test istaskdone(download_task)
             @test download_task.result isa RequestError
+
+            interrupt = Base.Event()
+            url = "$server/put"
+            input=`sh -c 'sleep 15; echo "hello"'`
+            download_task = @async request(url; interrupt=interrupt, input=input)
+            sleep(0.1)
+            @test !istaskdone(download_task)
+            notify(interrupt)
+            timedwait(()->istaskdone(download_task), 5.0)
+            @test istaskdone(download_task)
+            @test download_task.result isa RequestError
         end
 
         @testset "progress" begin


### PR DESCRIPTION
Cancelling an upload (PUT) request using the mechanism introduced in #256 was not effective. The upload task was not interrupted, which still blocked and the call to `request` did not return. With this change, cancelling also closes the `input` stream of the request to unblock the upload task.

Also changed the `interrupted` variable to be an `Atomic{Bool}`. Ref discussion [here](https://github.com/JuliaLang/Downloads.jl/pull/256#discussion_r1742148570).