### PR TITLE
CI: Use Dependabot to automatically update external GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # Intentionally a very high limit:
+    open-pull-requests-limit: 100
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
Follow-up to #252.

This will help us automatically keep our external Actions up to date.