### PR TITLE
Adapt expected protocol for response to invalid domain error

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -352,13 +352,21 @@ include("setup.jl")
         @test err isa RequestError
         @test err.code != 0
         @test startswith(err.message, "Could not resolve host")
-        @test err.response.proto === nothing
+        if Curl.CURL_VERSION < v"8.10"
+            @test err.response.proto === nothing
+        else
+            @test err.response.proto == "https"
+        end
 
         err = @exception request("https://domain.invalid", input = IOBuffer("Hi"))
         @test err isa RequestError
         @test err.code != 0
         @test startswith(err.message, "Could not resolve host")
-        @test err.response.proto === nothing
+        if Curl.CURL_VERSION < v"8.10"
+            @test err.response.proto === nothing
+        else
+            @test err.response.proto == "https"
+        end
 
         err = @exception download("$server/status/404")
         @test err isa RequestError


### PR DESCRIPTION
Tentatively fix #261.  As far as I understand, they just changed the protocol in the response and we need to adapt the tests.