### PR TITLE
Drop support (and CI) for Julia < 1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
-          - '1.6'
+          - '1.10'
           - '1' # automatically expands to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Downloads"
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 authors = ["Stefan Karpinski <stefan@karpinski.org> and contributors"]
-version = "1.6.0"
+version = "1.7.0"
 
 [deps]
 ArgTools = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -13,7 +13,7 @@ NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 ArgTools = "1.1"
 LibCURL = "0.6"
 NetworkOptions = "1.2"
-julia = "1.3"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Curl/utils.jl
+++ b/src/Curl/utils.jl
@@ -1,8 +1,3 @@
-if !@isdefined(contains)
-    contains(haystack, needle) = occursin(needle, haystack)
-    export contains
-end
-
 # basic C stuff
 
 puts(s::Union{String,SubString{String}}) = ccall(:puts, Cint, (Ptr{Cchar},), s)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -21,7 +21,7 @@ end
 function request_body(url::AbstractString; kwargs...)
     resp = nothing
     body = sprint() do output
-        resp = request(url; output=output, kwargs...)
+        resp = request(url; output, kwargs...)
     end
     return resp, body
 end


### PR DESCRIPTION
- **Drop support (and CI) for Julia < 1.10 (LTS)**
- **Adapt code to more recent Julia versions**
