### PR TITLE
Content-disposition: filename safe, filename* unsafe => use filename

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -265,10 +265,7 @@ function download(
     if output === nothing
         try_rename = true
         # guess file name from URL (might not be final name)
-        name = url_filename(url)
-        if !is_safe_filename(name)
-            name = DEFAULT_FILENAME
-        end
+        name = something(url_filename(url), DEFAULT_FILENAME)
         output = joinpath(mktempdir(), name)
     end
     local response # capture outside closure
@@ -290,7 +287,7 @@ function download(
     # fix file suffix based on headers & redirected URL
     if try_rename && ispath(path)
         name = get_filename(response)
-        if is_safe_filename(name)
+        if name !== nothing
             path′ = joinpath(dirname(path), name)
             @assert dirname(path) == dirname(path′)
             if path != path′

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,7 +227,11 @@ include("setup.jl")
             end
             for name in file_names,
                 url in urls_with_filename(name)
-                @test name === Downloads.url_filename(url)
+                if Sys.iswindows() && '"' in name
+                    @test nothing === Downloads.url_filename(url)
+                else
+                    @test name === Downloads.url_filename(url)
+                end
             end
             # URLs that we shouldn't get a file name from
             for url in [
@@ -315,6 +319,10 @@ include("setup.jl")
                 @test name⁺ == splitdir(download(url))[2]
                 url = content_disposition_url(:utf8 => name, :latin1 => name⁺)
                 @test name⁺ == splitdir(download(url))[2]
+            end
+            let name = "valid.txt", name⁺ = "invalid\0.txt"
+                url = content_disposition_url(:ascii => name, :utf8 => name⁺)
+                @test name == splitdir(download(url))[2]
             end
         end
         @testset "invalid content disposition" begin


### PR DESCRIPTION
This is very much an edge case, but it was bugging me. If the `filename` attribute is safe to use but the `filename*` attribute is unsafe then we use the `filename` instead of whatever the fallback would have been.
