### PR TITLE
Fix socket_callback / curl_multi_socket_action race condition

### DIFF
--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -159,6 +159,29 @@ function timer_callback(
     end
 end
 
+# Sometimes socket_callback doesn't finish before calling curl_multi_socket_action inside a task created by the callback
+# This likely has to do with how Julia takes ownership of C callback threads rather than yielding inside socket_callback
+# In order to let the callback finish so we can use the multi handle again, we need to yield to the event loop
+# Yielding just once should be sufficient, but include backoff behavior to account for external factors such as load
+function curl_multi_socket_action_retry(
+    multi_handle:: Ptr{Cvoid},
+    sock,
+    flags;
+    max_attempts=10,
+    f_backoff=(n) -> min(0.1, (1.0e-8 * (4.0^(n - 1) - 1.0))),
+)
+    r = 0
+    for n in 1:max_attempts
+        r = curl_multi_socket_action(multi_handle, sock, flags)
+        r == CURLM_RECURSIVE_API_CALL || break
+
+        # yield back to event loop until the curl callback for this multi returns
+        sleep(f_backoff(n))
+    end
+    r
+end
+
+
 function socket_callback(
     easy_h    :: Ptr{Cvoid},
     sock      :: curl_socket_t,
@@ -197,7 +220,7 @@ function socket_callback(
                         CURL_CSELECT_ERR * (events.disconnect || events.timedout)
                 lock(multi.lock) do
                     watcher.readable || watcher.writable || return # !isopen
-                    @check curl_multi_socket_action(multi.handle, sock, flags)
+                    @check curl_multi_socket_action_retry(multi.handle, sock, flags)
                     check_multi_info(multi)
                 end
             end

--- a/src/Curl/utils.jl
+++ b/src/Curl/utils.jl
@@ -65,7 +65,7 @@ macro reentrant_guard(ex::Expr)
             r = $(esc(ex))
             r == CURLM_RECURSIVE_API_CALL || break
             # yield back to event loop so the socket_callback can return
-            yield()
+            sleep(0.0)
         end
         iszero(r) || @async @error $prefix * string(r) maxlog=1_000
         r


### PR DESCRIPTION
## Bug Description

This fixes a race condition (https://github.com/JuliaLang/Downloads.jl/issues/272) that can occur when the `@async` task started inside `socket_callback` tries to call `curl_multi_socket_action` before `socket_callback` finishes. In practice this occurs when using gRPC concurrently, but it can be triggered without any concurrency even though its more rare. 

## Impact

The impact of this bug is high on any gRPC users within the Julia ecosystem since it can result in non deterministic deadlocks, timeouts, and exceptions.

## Proposed Fix

Ideally there would some way to guarantee that the task created inside `socket_callback` does not start until the callback finishes, but that might be a bit out of my depth as a first time contributor. I did test using `@task` instead of `@async` and starting the task in a `finally` block at the end of `socket_callback` but it did not fix the problem, so I don't think it makes sense to include it here.

In practice this behavior can be completely mitigated by yielding to the event loop and retrying the call a single time upon `CURLM_RECURSIVE_API_CALL`.  I implemented this within a new function called `curl_multi_socket_action_retry` which is only used within `socket_callback`. A backoff function was included incase a single time was not sufficient due to external factors such as system load. I set the default number of retries to 10 before reporting an error message. The first retry has a sleep time of 0. Integrating the backoff function from [1, 10] there is a total of `0.00189087` seconds of sleep time, which seems pretty minimal especially considering its possible to observe deadlocks when not handling this behavior. 

## Checklist

This is my first time contributing to the Julia project, will do my best to listen to any feedback and get this bug fixed! 

- [x] Reviewed the CoC
- [x] Works seamlessly with the `@check` macro
- [x] Uses the same function definition styling and boolean expression flow control where possible
- [x] Uses the same whitespace conventions (four spaces I think?)
- [x] Changes are self contained in one file which contains a new function handling the observed behavior gracefully without impacting other areas of the code
- [x] Stress tested gRPC overnight with the initial version of these changes applied and didn't encounter the issue again
- [ ] Created test cases / MWE for behavior

## Testing

One thing I'm not sure how to do is create a good test for this, since presumably it seems to manifest itself mostly when used upstream by the gRPCClient.jl package. Will look into any issues with codecov. 

I could put together a MWE using the upstream package demonstrating the issue is easy to reproduce against a real gRPC endpoint if that would help. 