### PR TITLE
Add 'lookback' to TagBot workflow + remove DOCUMENTER_KEY

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,6 +4,9 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: "3"
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
@@ -12,4 +15,3 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
TagBot has not properly made TagBot GitHub releases for the past couple years (v1.5.3 is the latest release showing on GitHub for me and is from 2022; or maybe one would count v1.6.0 as the latest one, which is from 2021).

I'm no CI expert so this is a bit of a shot in the dark, but I thought maybe I'd copy-paste the TagBot.jl file, and remove the ssh DOCUMENTER_KEY, as this worked recently for one of my packages without docs.

---

EDIT: Oh wait, v1.6.0 *is* the latest release (Not sure why [v1.7.0](https://github.com/JuliaRegistries/General/blob/8f4cd6aa89013f2d1dfda5461e8748772d272f0f/D/Downloads/Versions.toml#L49) is in the General Registry but not available for me through `>pkg up` though). Anyway, didn't realize this was so stable. Sorry for the noise! 😅 