### PR TITLE
Prevent Curl multi callback races and recover failed downloaders

### DIFF
--- a/src/Curl/Easy.jl
+++ b/src/Curl/Easy.jl
@@ -366,23 +366,6 @@ function header_callback(
     end
 end
 
-# feed data to read_callback
-function upload_data(easy::Easy, input::IO)
-    while true
-        data = eof(input) ? nothing : readavailable(input)
-        easy.input === nothing && break
-        easy.input = data
-        curl_easy_pause(easy.handle, Curl.CURLPAUSE_CONT)
-        wait(easy.ready)
-        easy.input === nothing && break
-        if hasmethod(reset, (Base.Event,))
-            reset(easy.ready)
-        else
-            easy.ready = Threads.Event()
-        end
-    end
-end
-
 function read_callback(
     data   :: Ptr{Cchar},
     size   :: Csize_t,

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -94,6 +94,28 @@ function set_defaults(multi::Multi)
     # currently no defaults
 end
 
+# feed data to read_callback
+function upload_data(multi::Multi, easy::Easy, input::IO)
+    while true
+        data = eof(input) ? nothing : readavailable(input)
+        stopped = lock(multi.lock) do
+            easy.input === nothing && return true
+            easy.input = data
+            # Unpausing can invoke multi callbacks before returning.
+            curl_easy_pause(easy.handle, Curl.CURLPAUSE_CONT)
+            return false
+        end
+        stopped && break
+        wait(easy.ready)
+        easy.input === nothing && break
+        if hasmethod(reset, (Base.Event,))
+            reset(easy.ready)
+        else
+            easy.ready = Threads.Event()
+        end
+    end
+end
+
 # multi-socket handle state updates
 
 struct CURLMsg

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -97,11 +97,7 @@ function remove_handle(multi::Multi, easy::Easy)
                 done!(multi)
             elseif 0 < multi.grace < typemax(multi.grace)
                 multi.timer = Timer(multi.grace/1000) do timer
-                    lock(multi.lock) do
-                        multi.timer === timer || return
-                        multi.timer = nothing
-                        done!(multi)
-                    end
+                    expire_multi!(multi, timer)
                 end
             end
             unpreserve_handle(multi)
@@ -111,6 +107,15 @@ function remove_handle(multi::Multi, easy::Easy)
         wait(recovered)
     end
     connect_semaphore_release(easy)
+end
+
+function expire_multi!(multi::Multi, timer::Timer)
+    lock(multi.lock) do
+        multi.timer === timer || return
+        multi.timer = nothing
+        isempty(multi.easies) || return
+        done!(multi)
+    end
 end
 
 # multi-socket options

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -176,7 +176,8 @@ function recover_multi!(multi::Multi, operation::Symbol, code::CURLMcode)
                 result = curl_multi_remove_handle(multi.handle, easy.handle)
                 # A callback may yield after scheduling recovery.
                 result == CURLM_RECURSIVE_API_CALL && return true
-                result == CURLM_OK || error("curl_multi_remove_handle: $result")
+                result == CURLM_OK || @error(
+                    "curl_multi_remove_handle: $result", maxlog=1_000)
             end
             easies = copy(multi.easies)
             empty!(multi.easies)

--- a/src/Curl/Multi.jl
+++ b/src/Curl/Multi.jl
@@ -4,9 +4,13 @@ mutable struct Multi
     timer  :: Union{Nothing,Timer}
     easies :: Vector{Easy}
     grace  :: UInt64
+    failed    :: Bool
+    recovered :: Base.Event
 
     function Multi(grace::Integer = typemax(UInt64))
-        multi = new(ReentrantLock(), C_NULL, nothing, Easy[], grace)
+        recovered = Base.Event()
+        notify(recovered)
+        multi = new(ReentrantLock(), C_NULL, nothing, Easy[], grace, false, recovered)
         finalizer(done!, multi)
         @lock MULTIS_LOCK push!(filter!(m -> m.value isa Multi, MULTIS), WeakRef(multi))
         return multi
@@ -53,37 +57,58 @@ end
 
 function add_handle(multi::Multi, easy::Easy)
     connect_semaphore_acquire(easy)
-    lock(multi.lock) do
-        if isempty(multi.easies)
-            preserve_handle(multi)
+    added = lock(multi.lock) do
+        if multi.failed
+            abort_easy!(easy)
+            return false
         end
-        push!(multi.easies, easy)
         init!(multi)
-        @check curl_multi_add_handle(multi.handle, easy.handle)
+        code = curl_multi_add_handle(multi.handle, easy.handle)
+        if code != CURLM_OK
+            fail_multi!(multi, :curl_multi_add_handle, code)
+            abort_easy!(easy)
+            return false
+        end
+        isempty(multi.easies) && preserve_handle(multi)
+        push!(multi.easies, easy)
+        return true
     end
+    added || connect_semaphore_release(easy)
 end
 
 const MULTIS_LOCK = Base.ReentrantLock()
 const MULTIS = WeakRef[]
 
 function remove_handle(multi::Multi, easy::Easy)
-    lock(multi.lock) do
-        @check curl_multi_remove_handle(multi.handle, easy.handle)
-        deleteat!(multi.easies, findlast(==(easy), multi.easies)::Int)
-        isempty(multi.easies) || return
-        stoptimer!(multi)
-        if multi.grace <= 0
-            done!(multi)
-        elseif 0 < multi.grace < typemax(multi.grace)
-            multi.timer = Timer(multi.grace/1000) do timer
-                lock(multi.lock) do
-                    multi.timer === timer || return
-                    multi.timer = nothing
-                    done!(multi)
+    while true
+        recovered = lock(multi.lock) do
+            i = findlast(==(easy), multi.easies)
+            i === nothing && return nothing
+            multi.failed && return multi.recovered
+            code = curl_multi_remove_handle(multi.handle, easy.handle)
+            if code != CURLM_OK
+                fail_multi!(multi, :curl_multi_remove_handle, code)
+                return multi.recovered
+            end
+            deleteat!(multi.easies, i)
+            isempty(multi.easies) || return nothing
+            stoptimer!(multi)
+            if multi.grace <= 0
+                done!(multi)
+            elseif 0 < multi.grace < typemax(multi.grace)
+                multi.timer = Timer(multi.grace/1000) do timer
+                    lock(multi.lock) do
+                        multi.timer === timer || return
+                        multi.timer = nothing
+                        done!(multi)
+                    end
                 end
             end
+            unpreserve_handle(multi)
+            return nothing
         end
-        unpreserve_handle(multi)
+        recovered === nothing && break
+        wait(recovered)
     end
     connect_semaphore_release(easy)
 end
@@ -118,6 +143,54 @@ end
 
 # multi-socket handle state updates
 
+function abort_easy!(easy::Easy)
+    easy.code = CURLE_ABORTED_BY_CALLBACK
+    close(easy.progress)
+    close(easy.output)
+    easy.input = nothing
+    notify(easy.ready)
+    nothing
+end
+
+function fail_multi!(multi::Multi, operation::Symbol, code::CURLMcode)
+    multi.failed && return
+    multi.failed = true
+    reset(multi.recovered)
+    # Recover after returning from the libcurl callback stack.
+    task = @async recover_multi!(multi, operation, code)
+    @isdefined(errormonitor) && errormonitor(task)
+    nothing
+end
+
+function recover_multi!(multi::Multi, operation::Symbol, code::CURLMcode)
+    @error "$operation: $code" maxlog=1_000
+    while true
+        retry = lock(multi.lock) do
+            multi.failed || return false
+            for easy in multi.easies
+                result = curl_multi_remove_handle(multi.handle, easy.handle)
+                # A callback may yield after scheduling recovery.
+                result == CURLM_RECURSIVE_API_CALL && return true
+                result == CURLM_OK || error("curl_multi_remove_handle: $result")
+            end
+            easies = copy(multi.easies)
+            empty!(multi.easies)
+            isempty(easies) || unpreserve_handle(multi)
+            stoptimer!(multi)
+            done!(multi)
+            for easy in easies
+                abort_easy!(easy)
+                connect_semaphore_release(easy)
+            end
+            multi.failed = false
+            notify(multi.recovered)
+            return false
+        end
+        retry || return
+        yield()
+    end
+end
+
 struct CURLMsg
    msg  :: CURLMSG
    easy :: Ptr{Cvoid}
@@ -149,7 +222,12 @@ end
 # curl callbacks
 
 function do_multi(multi::Multi)
-    @check curl_multi_socket_action(multi.handle, CURL_SOCKET_TIMEOUT, 0)
+    multi.failed && return
+    code = curl_multi_socket_action(multi.handle, CURL_SOCKET_TIMEOUT, 0)
+    if code != CURLM_OK
+        fail_multi!(multi, :curl_multi_socket_action, code)
+        return
+    end
     check_multi_info(multi)
 end
 
@@ -218,8 +296,13 @@ function socket_callback(
                         CURL_CSELECT_OUT * iswritable(events) +
                         CURL_CSELECT_ERR * (events.disconnect || events.timedout)
                 lock(multi.lock) do
+                    multi.failed && return
                     watcher.readable || watcher.writable || return # !isopen
-                    @check curl_multi_socket_action(multi.handle, sock, flags)
+                    code = curl_multi_socket_action(multi.handle, sock, flags)
+                    if code != CURLM_OK
+                        fail_multi!(multi, :curl_multi_socket_action, code)
+                        return
+                    end
                     check_multi_info(multi)
                 end
             end

--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -455,7 +455,7 @@ function request(
                             end
                         end
                         if have_input
-                            @async upload_data(easy, input)
+                            @async upload_data(downloader′.multi, easy, input)
                         end
                     end
                 finally

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -611,6 +611,24 @@ const ABORT_SOCKET_CALLBACK = @cfunction(
             end
         end
 
+        @testset "grace cleanup with active handles" begin
+            Curl.with_handle(Curl.Multi()) do multi
+                Curl.init!(multi)
+                handle = multi.handle
+                timer = Timer(60)
+                multi.timer = timer
+
+                Curl.with_handle(Curl.Easy()) do easy
+                    push!(multi.easies, easy)
+                    Curl.expire_multi!(multi, timer)
+                    @test multi.handle == handle
+                    @test multi.timer === nothing
+                    empty!(multi.easies)
+                end
+                close(timer)
+            end
+        end
+
         @testset "multi callback failure" begin
             multi = Curl.Multi()
             Curl.with_handle(Curl.Easy()) do easy

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,21 @@
 include("setup.jl")
 
+function abort_socket_callback(
+    easy_h    :: Ptr{Cvoid},
+    sock      :: Curl.curl_socket_t,
+    action    :: Cint,
+    multi_p   :: Ptr{Cvoid},
+    watcher_p :: Ptr{Cvoid},
+)::Cint
+    return -1
+end
+
+const ABORT_SOCKET_CALLBACK = @cfunction(
+    abort_socket_callback,
+    Cint,
+    (Ptr{Cvoid}, Curl.curl_socket_t, Cint, Ptr{Cvoid}, Ptr{Cvoid}),
+)
+
 @testset "Downloads.jl" begin
     @testset "libcurl configuration" begin
         julia = "$(VERSION.major).$(VERSION.minor)"
@@ -593,6 +609,55 @@ include("setup.jl")
                     wait(upload)
                 end
             end
+        end
+
+        @testset "multi callback failure" begin
+            multi = Curl.Multi()
+            Curl.with_handle(Curl.Easy()) do easy
+                Curl.set_url(easy, "$server/delay/1")
+                Curl.set_body(easy, true)
+                Curl.init!(multi)
+                Curl.setopt(multi, Curl.CURLMOPT_SOCKETFUNCTION, ABORT_SOCKET_CALLBACK)
+                Curl.add_handle(multi, easy)
+
+                @test timedwait(() -> easy.code != typemax(Curl.CURLcode), 5) == :ok
+                @test easy.code == Curl.CURLE_ABORTED_BY_CALLBACK
+                @test timedwait(() -> !multi.failed, 5) == :ok
+                @test isempty(multi.easies)
+                @test multi.handle == C_NULL
+                Curl.remove_handle(multi, easy)
+            end
+
+            output = IOBuffer()
+            downloader = Downloader(multi)
+            response = request("$server/get"; output, downloader, throw=false)
+            @test response isa Response
+        end
+
+        @testset "recursive debug callback" begin
+            downloader = Downloader()
+            nested = Ref{Union{Nothing,Response,RequestError}}(nothing)
+            entered = Ref(false)
+            debug = function (type, message)
+                entered[] && return
+                entered[] = true
+                nested[] = request("file://$(abspath(@__FILE__))";
+                    output=IOBuffer(), downloader, throw=false)
+            end
+
+            outer = @test_logs (:error, r"curl_multi_add_handle: 8") request(
+                "$server/delay/1";
+                output=IOBuffer(), debug, downloader, throw=false,
+            )
+            @test nested[] isa RequestError
+            @test nested[].code == Curl.CURLE_ABORTED_BY_CALLBACK
+            @test outer isa RequestError
+            @test timedwait(() -> !downloader.multi.failed, 5) == :ok
+
+            output = IOBuffer()
+            response = request("file://$(abspath(@__FILE__))";
+                output, downloader, throw=false)
+            @test response isa Response
         end
 
         @testset "basic request usage" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -571,6 +571,30 @@ include("setup.jl")
     end
 
     @testset "request API" begin
+        @testset "upload serialization" begin
+            Curl.with_handle(Curl.Multi()) do multi
+                Curl.with_handle(Curl.Easy()) do easy
+                    locked = Channel{Nothing}(1)
+                    release = Base.Event()
+                    holder = Threads.@spawn lock(multi.lock) do
+                        put!(locked, nothing)
+                        wait(release)
+                    end
+                    take!(locked)
+
+                    notify(easy.ready)
+                    upload = Threads.@spawn Curl.upload_data(multi, easy, IOBuffer())
+                    yield()
+                    @test !istaskdone(upload)
+
+                    notify(release)
+                    @test timedwait(() -> istaskdone(holder) && istaskdone(upload), 5) == :ok
+                    wait(holder)
+                    wait(upload)
+                end
+            end
+        end
+
         @testset "basic request usage" begin
             for status in [200, 400, 404]
                 url = "$server/status/$status"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -652,6 +652,34 @@ const ABORT_SOCKET_CALLBACK = @cfunction(
             @test response isa Response
         end
 
+        @testset "failed recovery cleanup" begin
+            multi = Curl.Multi()
+            Curl.with_handle(Curl.Easy()) do easy
+                Curl.set_url(easy, "file://$(abspath(@__FILE__))")
+                Curl.add_handle(multi, easy)
+                @test Curl.curl_multi_remove_handle(multi.handle, easy.handle) ==
+                    Curl.CURLM_OK
+                Curl.done!(multi)
+
+                @test_logs(
+                    (:error, r"forced_recovery: 1"),
+                    (:error, r"curl_multi_remove_handle: 1"),
+                    begin
+                        Curl.fail_multi!(multi, :forced_recovery, Curl.CURLM_BAD_HANDLE)
+                        @test timedwait(() -> !multi.failed, 5) == :ok
+                    end,
+                )
+                @test easy.code == Curl.CURLE_ABORTED_BY_CALLBACK
+                @test isempty(multi.easies)
+                Curl.remove_handle(multi, easy)
+            end
+
+            output = IOBuffer()
+            response = request("file://$(abspath(@__FILE__))";
+                output, downloader=Downloader(multi), throw=false)
+            @test response isa Response
+        end
+
         @testset "recursive debug callback" begin
             downloader = Downloader()
             nested = Ref{Union{Nothing,Response,RequestError}}(nothing)


### PR DESCRIPTION
The new Buildkite scheduler is based on Julia 1.10 + Downloads.jl, and happened to lock up after a few days with `curl_multi_remove_handle: 8` (`CURLM_RECURSIVE_API_CALL`) errors. There seems to be several issues like that in here (#239, #245, #253, #272) so I figured I'd have Fable/5.6-sol take a stab at it.

Context: I'm using the default downloader (so a single `Multi`) to handle concurrent GET, PUT and POST requests.

The LLM spotted a few issues:

## Upload resumption was not serialized

`curl_easy_pause(CURLPAUSE_CONT)` may invoke callbacks before returning, but the upload path called it without holding `multi.lock`.

Move `upload_data` to `Multi` and hold the lock while publishing `easy.input` and unpausing the transfer.

## Multi errors did not reach callers

Nonzero add, remove, and socket-action results were logged, after which Downloads continued using the same multi. This could leave current and future requests permanently stuck.

Mark the multi failed, stop driving it, and recover asynchronously after the current callback returns. Recovery detaches and aborts all easies, wakes their callers, releases connection permits, and rebuilds the native multi for later requests.

## Handle bookkeeping was not transactional

An easy was recorded before native add succeeded, and removed from Julia bookkeeping even if native removal failed.

Only update `multi.easies` after the corresponding native operation succeeds. Make removal idempotent and recovery-aware.

## Grace cleanup could destroy an active multi

A queued grace timer could clean up a multi that had acquired new handles.

Before cleanup, recheck under `multi.lock` that the timer is current and the easy list is still empty.

## Detach errors could strand recovery

An unexpected error while detaching an easy terminated the recovery task, leaving `multi.failed` set and waiters blocked forever.

Log detach errors, but always finish cleanup and notify recovery waiters.