### PR TITLE
remove a[] = v pattern for atomic variable

### DIFF
--- a/src/Downloads.jl
+++ b/src/Downloads.jl
@@ -437,7 +437,7 @@ function request(
                         remove_handle(downloader′.multi, easy)
                         close(easy.output)
                         close(easy.progress)
-                        interrupted[] = true
+                        Threads.atomic_xchg!(interrupted, true)
                         close(input)
                         notify(easy.ready)
                     end


### PR DESCRIPTION
This will be deprecated some version after JuliaLang/julia#62382 migrates the API fully to `@atomic`.